### PR TITLE
Fix outgoing transfers to real LocalSend peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Present the Nearby TLS identity when sending. LocalSend peers ask for a client
   certificate during the handshake, so every outgoing transfer to a real device
   was aborted with `certificate required` and surfaced as "Transfer failed".
+- Choose files with `omarchy-file-select` instead of `zenity`, which Omarchy does
+  not ship. Selecting files opened nothing at all on a stock system.
+- Report a helper command that never launched. Quickshell signals that by
+  returning `running` to false without an exit code, so the previous checks for
+  exit code 127 could not run and the failure was silent.
 
 ## 1.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Present the Nearby TLS identity when sending. LocalSend peers ask for a client
+  certificate during the handshake, so every outgoing transfer to a real device
+  was aborted with `certificate required` and surfaced as "Transfer failed".
+
 ## 1.0.4
 
 - Fix copying received text with the Quickshell `Process` API and keep repeated

--- a/Panel.qml
+++ b/Panel.qml
@@ -150,8 +150,10 @@ Panel {
   function stopDiscovery() { discoveryActive = false; send({command:"discovery_stop"}) }
   function chooseDevice(index) { if (index >= 0 && index < devices.length) { selectedDevice = devices[index]; viewState = "target"; selectedIndex = 0 } }
   function goBack() { if (viewState === "pin") cancelPin(); else if (viewState === "target") { viewState = "nearby"; selectedDevice = null; selectedIndex = 0 } else close() }
-  function selectFiles() { if (!selectedDevice || picker.running) return; picker.running = true }
-  function sendClipboard() { if (!selectedDevice || clipboard.running) return; clipboard.running = true }
+  function failWith(message) { viewState="error"; errorText=message; statusText=errorText }
+  function selectFiles() { if (!selectedDevice || picker.running) return; picker.launched=false; picker.running = true }
+  function sendClipboard() { if (!selectedDevice || clipboard.running) return; clipboard.launched=false; clipboard.running = true }
+  function copyReceivedText() { clipboardWriter.launched=false; clipboardWriter.running=true }
   function clearPendingOutgoing() { pendingOutgoing=null; outgoingTransferId=""; pinError=""; pinInput.text="" }
   function dispatchPendingOutgoing(pin) {
     if (!pendingOutgoing) return
@@ -236,7 +238,7 @@ Panel {
     if (viewState === "nearby") selectedIndex < 0 ? toggleReceiver() : (selectedIndex === devices.length ? forceFullDiscovery() : chooseDevice(selectedIndex))
     else if (viewState === "target") selectedIndex === 0 ? selectFiles() : sendClipboard()
     else if (viewState === "incoming") selectedIndex === 0 ? declineIncoming() : acceptIncoming()
-    else if (viewState === "text") { if(selectedIndex===0)clipboardWriter.running=true; else finishText() }
+    else if (viewState === "text") { if(selectedIndex===0)copyReceivedText(); else finishText() }
     else if (viewState === "sending") send({command:"cancel_outgoing",transfer_id:outgoingTransferId})
     else if (viewState === "success" || viewState === "error") finishTerminal()
   }
@@ -361,13 +363,22 @@ Panel {
     }
   }
 
+  // Quickshell reports a command it could not launch by returning `running` to
+  // false without ever emitting `started` or `exited`, so a missing binary has
+  // to be caught there. Exit codes never carry that news: nothing runs a shell
+  // on our behalf, so the 127 a shell would report cannot reach us.
   Process {
     id: picker
-    command: ["zenity","--file-selection","--multiple","--separator=\n","--title=Send nearby"]
+    property bool launched: false
+    command: ["omarchy-file-select","--title","Send nearby","--multiple"]
     running: false
     stdout: StdioCollector { id: pickerOutput; waitForEnd: true }
+    onStarted: picker.launched=true
+    onRunningChanged: if (!running && !picker.launched) root.failWith("The file chooser could not be started")
     onExited: function(code) {
-      if (code === 127) { root.viewState="error"; root.errorText="zenity is required to choose files"; root.statusText=root.errorText; return }
+      // The chooser separates a decision from a fault: 1 is nobody picking
+      // anything, and anything above it is a chooser that never opened.
+      if (code > 1) { root.failWith("The file chooser did not open"); return }
       if (code !== 0 || !root.selectedDevice) return
       var paths=String(pickerOutput.text || "").split("\n").filter(function(v){return v.trim()!==""})
       if (paths.length) root.beginOutgoing({kind:"files",device:root.selectedDevice,paths:paths})
@@ -375,13 +386,16 @@ Panel {
   }
   Process {
     id: clipboard
+    property bool launched: false
     command: ["wl-paste","--no-newline","--type","text"]
     running: false
     stdout: StdioCollector { id: clipboardOutput; waitForEnd: true }
+    onStarted: clipboard.launched=true
+    onRunningChanged: if (!running && !clipboard.launched) root.failWith("wl-paste is required to read the clipboard")
     onExited: function(code) {
       var text=String(clipboardOutput.text || "")
       if (code===0 && text.trim()!=="" && root.selectedDevice) root.beginOutgoing({kind:"text",device:root.selectedDevice,text:text})
-      else { root.viewState="error"; root.errorText=code===127 ? "wl-paste is required to read the clipboard" : "Clipboard is empty"; root.statusText=root.errorText }
+      else root.failWith("Clipboard is empty")
     }
   }
 
@@ -494,7 +508,7 @@ Panel {
           PanelSectionHeader { text:"RECEIVED TEXT"; foreground:root.foreground; fontFamily:root.fontFamily }
           Text { width:parent.width; textFormat:Text.PlainText; text:root.incomingText; wrapMode:Text.Wrap; maximumLineCount:6; elide:Text.ElideRight; color:root.foreground; font.family:root.fontFamily; font.pixelSize:Style.font.body }
           Row { width:parent.width; spacing:Style.space(8)
-            Button { width:(parent.width-parent.spacing)/2; text:"Copy"; iconText:"󰆏"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onClicked:{clipboardWriter.running=true} }
+            Button { width:(parent.width-parent.spacing)/2; text:"Copy"; iconText:"󰆏"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onClicked:{root.copyReceivedText()} }
             Button { width:(parent.width-parent.spacing)/2; text:"Done"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===1; onClicked:root.finishText() }
           }
         }
@@ -504,10 +518,12 @@ Panel {
 
   Process {
     id: clipboardWriter
+    property bool launched: false
     command: ["wl-copy"]
     running: false
     stdinEnabled: true
-    onStarted: { write(root.incomingText); stdinEnabled=false }
-    onExited: function(code) { stdinEnabled=true; if(root.viewState!=="text")return; if(code===0){root.viewState="success";root.statusText="Received"} else {root.viewState="error";root.errorText="wl-copy is required to copy received text";root.statusText=root.errorText} }
+    onStarted: { clipboardWriter.launched=true; write(root.incomingText); stdinEnabled=false }
+    onRunningChanged: if (!running && !clipboardWriter.launched && root.viewState==="text") root.failWith("wl-copy is required to copy received text")
+    onExited: function(code) { stdinEnabled=true; if(root.viewState!=="text")return; if(code===0){root.viewState="success";root.statusText="Received"} else root.failWith("wl-copy is required to copy received text") }
   }
 }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The widget is placed in the right section of the bar by default. Remove it with
 Runtime:
 
 - Omarchy Quattro (Quickshell-based shell)
-- `zenity` for file selection
+- `omarchy-file-select` for file selection, which Omarchy ships
 - `wl-clipboard` (`wl-copy` / `wl-paste`) for text sharing
 - `libnotify` (`notify-send`) for desktop notifications
 - Local network connectivity for LocalSend traffic (default TCP/UDP port `53317`)

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1148,9 +1148,12 @@ version = "1.0.4"
 dependencies = [
  "anyhow",
  "localsend-rs",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,6 +13,12 @@ tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+# A LocalSend peer asks for a client certificate, which the in-process test
+# server never does. Standing up a listener that demands one keeps outgoing
+# HTTPS transfers honest.
+rustls = { version = "0.23.36", features = ["ring"] }
+rustls-pemfile = "2.2"
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 
 [profile.release]
 lto = "thin"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -492,6 +492,7 @@ async fn start_active_discovery(
 async fn send_payload(
     transfer_id: String,
     identity: DeviceInfo,
+    certificate: TlsCertificate,
     target: DeviceInfo,
     paths: Vec<String>,
     text: Option<String>,
@@ -501,10 +502,15 @@ async fn send_payload(
     if target.ip.as_deref().unwrap_or("").is_empty() {
         return Err(anyhow!("device disappeared"));
     }
+    // LocalSend peers request a client certificate during the TLS handshake, so
+    // an outgoing transfer has to present the same identity the receiver and the
+    // HTTP discovery probes already use. Connecting without one is refused with
+    // a `certificate required` alert before the first request is answered.
     let client = if target.protocol == Protocol::Https {
-        LocalSendClient::with_trust_policy(
+        LocalSendClient::with_trust_policy_and_identity(
             identity,
             TlsTrustPolicy::new([target.fingerprint.clone()]),
+            &certificate,
         )?
     } else {
         LocalSendClient::new(identity)
@@ -868,8 +874,8 @@ async fn main() -> Result<()> {
                     Command::SendFiles { transfer_id,device,paths,pin } => {
                         if outgoing.is_some(){emit(json!({"event":"outgoing_failed","transferId":transfer_id,"message":"Another transfer is already active"}));continue;}
                         let (tx,rx)=oneshot::channel(); outgoing=Some(OutgoingControl{id:transfer_id.clone(),cancel:tx});
-                        let (identity,done)=(identity.clone(),out_done_tx.clone()); tokio::spawn(async move {
-                            let event=match send_payload(transfer_id.clone(),identity,device,paths,None,pin,rx).await {
+                        let (identity,certificate,done)=(identity.clone(),certificate.clone(),out_done_tx.clone()); tokio::spawn(async move {
+                            let event=match send_payload(transfer_id.clone(),identity,certificate,device,paths,None,pin,rx).await {
                                 Ok(SendPayloadOutcome::Finished)=>None,
                                 Ok(SendPayloadOutcome::PinRequired)=>Some(json!({"event":"outgoing_pin_required","transferId":transfer_id})),
                                 Ok(SendPayloadOutcome::InvalidPin)=>Some(json!({"event":"outgoing_invalid_pin","transferId":transfer_id})),
@@ -881,8 +887,8 @@ async fn main() -> Result<()> {
                     Command::SendText { transfer_id,device,text,pin } => {
                         if outgoing.is_some(){emit(json!({"event":"outgoing_failed","transferId":transfer_id,"message":"Another transfer is already active"}));continue;}
                         let (tx,rx)=oneshot::channel(); outgoing=Some(OutgoingControl{id:transfer_id.clone(),cancel:tx});
-                        let (identity,done)=(identity.clone(),out_done_tx.clone()); tokio::spawn(async move {
-                            let event=match send_payload(transfer_id.clone(),identity,device,vec![],Some(text),pin,rx).await {
+                        let (identity,certificate,done)=(identity.clone(),certificate.clone(),out_done_tx.clone()); tokio::spawn(async move {
+                            let event=match send_payload(transfer_id.clone(),identity,certificate,device,vec![],Some(text),pin,rx).await {
                                 Ok(SendPayloadOutcome::Finished)=>None,
                                 Ok(SendPayloadOutcome::PinRequired)=>Some(json!({"event":"outgoing_pin_required","transferId":transfer_id})),
                                 Ok(SendPayloadOutcome::InvalidPin)=>Some(json!({"event":"outgoing_invalid_pin","transferId":transfer_id})),
@@ -1019,11 +1025,13 @@ mod tests {
         target.ip = Some("127.0.0.1".into());
         target.fingerprint = "pin-test-target".into();
         let identity = DeviceInfo::new("Nearby test".into(), 53317, Protocol::Http);
+        let certificate = generate_tls_certificate().unwrap();
 
         let (cancel_tx, cancel_rx) = oneshot::channel();
         let missing = send_payload(
             "pin-missing".into(),
             identity.clone(),
+            certificate.clone(),
             target.clone(),
             vec![],
             Some("hello".into()),
@@ -1039,6 +1047,7 @@ mod tests {
         let invalid = send_payload(
             "pin-invalid".into(),
             identity.clone(),
+            certificate.clone(),
             target.clone(),
             vec![],
             Some("hello".into()),
@@ -1054,6 +1063,7 @@ mod tests {
         let accepted = send_payload(
             "pin-valid".into(),
             identity,
+            certificate,
             target,
             vec![],
             Some("hello".into()),
@@ -1067,6 +1077,127 @@ mod tests {
 
         server.stop();
         tokio::fs::remove_dir_all(directory).await.unwrap();
+    }
+
+    /// Accepts every client certificate and records that one arrived at all.
+    /// Rejecting is `rustls`' job: a client that presents nothing never reaches
+    /// this verifier, so the flag alone distinguishes the two.
+    #[derive(Debug)]
+    struct RecordingClientVerifier {
+        presented: Arc<std::sync::atomic::AtomicBool>,
+        algorithms: rustls::crypto::WebPkiSupportedAlgorithms,
+    }
+
+    impl rustls::server::danger::ClientCertVerifier for RecordingClientVerifier {
+        fn root_hint_subjects(&self) -> &[rustls::DistinguishedName] {
+            &[]
+        }
+
+        fn verify_client_cert(
+            &self,
+            _end_entity: &rustls::pki_types::CertificateDer<'_>,
+            _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+            _now: rustls::pki_types::UnixTime,
+        ) -> std::result::Result<rustls::server::danger::ClientCertVerified, rustls::Error>
+        {
+            self.presented
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(rustls::server::danger::ClientCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &rustls::pki_types::CertificateDer<'_>,
+            dss: &rustls::DigitallySignedStruct,
+        ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
+        {
+            rustls::crypto::verify_tls12_signature(message, cert, dss, &self.algorithms)
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &rustls::pki_types::CertificateDer<'_>,
+            dss: &rustls::DigitallySignedStruct,
+        ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error>
+        {
+            rustls::crypto::verify_tls13_signature(message, cert, dss, &self.algorithms)
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            self.algorithms.supported_schemes()
+        }
+    }
+
+    #[tokio::test]
+    async fn outgoing_https_transfer_presents_a_client_certificate() {
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let presented = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let receiver_certificate = generate_tls_certificate().unwrap();
+        let key = rustls_pemfile::private_key(&mut std::io::Cursor::new(
+            receiver_certificate.key_pem.as_bytes(),
+        ))
+        .unwrap()
+        .unwrap();
+        let config = rustls::ServerConfig::builder_with_provider(provider.clone())
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_client_cert_verifier(Arc::new(RecordingClientVerifier {
+                presented: presented.clone(),
+                algorithms: provider.signature_verification_algorithms,
+            }))
+            .with_single_cert(
+                vec![rustls::pki_types::CertificateDer::from(
+                    receiver_certificate.cert_der.clone(),
+                )],
+                key,
+            )
+            .unwrap();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(config));
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let acceptor = acceptor.clone();
+                // Finish the handshake, then hang up. The peer only has to be
+                // real enough to demand a certificate; answering the request
+                // would test the receiver, which is not what is at stake here.
+                tokio::spawn(async move {
+                    let _ = acceptor.accept(stream).await;
+                });
+            }
+        });
+
+        let mut target = DeviceInfo::new("Mutual TLS".into(), port, Protocol::Https);
+        target.ip = Some("127.0.0.1".into());
+        target.fingerprint = receiver_certificate.fingerprint.clone();
+        let identity = DeviceInfo::new("Nearby test".into(), 53317, Protocol::Https);
+        let certificate = generate_tls_certificate().unwrap();
+
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        let _ = tokio::time::timeout(
+            Duration::from_secs(20),
+            send_payload(
+                "mutual-tls".into(),
+                identity,
+                certificate,
+                target,
+                vec![],
+                Some("hello".into()),
+                None,
+                cancel_rx,
+            ),
+        )
+        .await;
+        drop(cancel_tx);
+
+        assert!(
+            presented.load(std::sync::atomic::Ordering::SeqCst),
+            "an outgoing HTTPS transfer must present a client certificate, \
+             or a LocalSend peer aborts the handshake with `certificate required`"
+        );
     }
 
     #[test]

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -6,10 +6,22 @@ const Model = require("../Model.js")
 const source = fs.readFileSync(require.resolve("../Panel.qml"), "utf8")
 
 assert.equal(source.includes("closeStdin"), false, "Quickshell Process does not expose closeStdin")
-assert.match(source, /onStarted:\s*\{\s*write\(root\.incomingText\);\s*stdinEnabled=false\s*\}/,
+assert.match(source, /onStarted:\s*\{[^}]*write\(root\.incomingText\);\s*stdinEnabled=false\s*\}/,
   "clipboard writer must close stdin after writing so wl-copy can finish")
 assert.match(source, /onExited:\s*function\(code\)\s*\{\s*stdinEnabled=true;/,
   "clipboard writer must re-enable stdin for the next copy")
+
+assert.equal(source.includes("zenity"), false,
+  "files are chosen with omarchy-file-select, which Omarchy ships, rather than zenity")
+assert.match(source, /command:\s*\["omarchy-file-select"/,
+  "the file chooser must be omarchy-file-select")
+assert.equal(/code\s*===?\s*127/.test(source), false,
+  "no shell runs on our behalf, so a missing command never reports exit code 127")
+for (const launcher of ["picker", "clipboard", "clipboardWriter"]) {
+  assert.match(source, new RegExp(`onRunningChanged:\\s*if\\s*\\(!running && !${launcher}\\.launched`),
+    `${launcher} must report a command that never launched, which Quickshell signals by ` +
+    "returning running to false without an exit code")
+}
 
 function extractFunction(name) {
   const marker = `function ${name}`
@@ -375,10 +387,17 @@ function incoming(requestId, sender = requestId) {
 }
 
 assert.match(source,
-  /Clipboard is empty"\s*;?\s*root\.statusText=root\.errorText/,
-  "clipboard read errors must keep statusText aligned with errorText")
-assert.match(source,
-  /wl-copy is required to copy received text"\s*;?\s*root\.statusText=root\.errorText/,
-  "clipboard write errors must keep statusText aligned with errorText")
+  /function failWith\(message\)\s*\{\s*viewState="error";\s*errorText=message;\s*statusText=errorText\s*\}/,
+  "failWith must keep statusText aligned with errorText for every failure that reaches it")
+for (const [failure, description] of [
+  ["Clipboard is empty", "clipboard read"],
+  ["wl-paste is required to read the clipboard", "missing wl-paste"],
+  ["wl-copy is required to copy received text", "clipboard write"],
+  ["The file chooser could not be started", "missing file chooser"],
+  ["The file chooser did not open", "file chooser fault"],
+]) {
+  assert.match(source, new RegExp(`failWith\\("${failure.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"\\)`),
+    `${description} errors must be raised through failWith`)
+}
 
 console.log("panel state tests passed")


### PR DESCRIPTION
Sending anything from Nearby fails on a stock Omarchy install. Two separate causes, both on the send path; receiving is unaffected.

## 1. Clipboard text and files report "Transfer failed"

LocalSend peers ask for a client certificate during the TLS handshake. `send_payload` built its client with `with_trust_policy`, which passes no identity, so the peer aborts the connection before answering `prepare-upload`:

```
TLSv1.3 (IN), TLS alert, unknown (628):
SSL routines::tlsv13 alert certificate required
```

Confirmed against a phone running LocalSend 2.2, same host, same certificate:

| client | result |
| --- | --- |
| no client certificate | `AlertReceived(CertificateRequired)` |
| client certificate | `HTTP 200`, `prepare_upload` accepted |

The resulting error text matches none of the buckets in `human_error`, so it falls through to the generic "Transfer failed" and gives no hint about what went wrong.

The receiver and the HTTP discovery probes already pass this identity — `start_active_discovery` hands it to `HttpDiscovery::new_with_device_and_identity`. Only the send path was missing it, so discovery lists a device that every transfer to it then fails.

**Why the suite stayed green:** the test peer is `LocalSendServer`, whose TLS config is built with `with_no_client_auth`. It is more permissive than any real LocalSend peer and never asks for the certificate the client failed to send. The added test stands up a listener that does require one; it fails against the previous client and passes with the fix.

## 2. Choosing files opens nothing

The picker ran `zenity`, which Omarchy does not install, so the dialog never appeared.

The failure was also invisible. Quickshell launches a command directly rather than through a shell, so a missing binary returns `running` to false without ever emitting `started` or `exited` — the exit code 127 these handlers tested for is a shell's report and cannot reach them:

```
WARN: Process failed to start, likely because the binary could not be found.
Command: QList("zenity", "--file-selection", "--multiple", ...)
```

Two clicks, two warnings, no error shown and no dialog.

This switches to `omarchy-file-select`, the portal-backed chooser Omarchy ships and already uses in `omarchy share` and `omarchy tailscale send`, and reads the exit codes it defines: 1 is nobody picking anything, above 1 is a chooser that never opened. It also tracks whether each command started and reports the ones that did not, covering `wl-paste` and `wl-copy` alongside the chooser, so a missing dependency can no longer fail silently.

## Tests

- `outgoing_https_transfer_presents_a_client_certificate` — a TLS listener requiring a client certificate; fails without the first fix.
- `tests/panel-state.test.js` — asserts the chooser command, the absence of unreachable 127 checks, and a start-failure guard on each launcher.
- Full CI locally: 23 helper tests, 102 vendored `localsend-rs` tests, both frontend suites, `cargo fmt --check`.

Verified end to end on Omarchy 4.0.0.alpha against a phone on the LAN: clipboard text and file sends both succeed, and removing the chooser now surfaces an error instead of doing nothing.