### PR TITLE
fix: run one Nearby engine per shell instead of one per monitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           components: rustfmt
 
       - name: Test frontend model
-        run: node tests/model.test.js && node tests/panel-state.test.js
+        run: node tests/model.test.js && node tests/panel-state.test.js && node tests/service-state.test.js
 
       - name: Check Rust formatting
         run: cargo fmt --manifest-path backend/Cargo.toml --all -- --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,11 @@ minimal and do not mix unrelated refactors into bug fixes.
 
 ## Architecture and compatibility
 
+- `Service.qml` owns the helper process, the transfer state machine, and the
+  `oma.nearby` IPC target. The shell loads a `service` kind once per session.
 - `Panel.qml` and `Model.js` implement the Quickshell UI and its state model.
+  The bar builds one `Panel.qml` per monitor, so it must stay a view: anything
+  there can only be one of belongs in `Service.qml`.
 - `backend/` contains the Rust helper. `backend/vendor/localsend-rs/` is a
   locally modified dependency and has its own independently runnable tests.
 - Preserve compatibility with Omarchy Quattro and the LocalSend protocol.
@@ -27,6 +31,7 @@ complete supported suite when practical:
 ```sh
 node tests/model.test.js
 node tests/panel-state.test.js
+node tests/service-state.test.js
 cargo fmt --manifest-path backend/Cargo.toml --all -- --check
 cargo check --locked --manifest-path backend/Cargo.toml
 cargo test --locked --manifest-path backend/Cargo.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
   `service` entry point that the shell loads once, and each bar widget is a
   view onto it. The IPC target was registered once per monitor for the same
   reason, and the shell kept only the first registration.
+- Keep a receiver the user turned off turned off. The setting is now read from
+  `shell.json` rather than pushed in by a bar widget. Widgets are built once per
+  monitor and receive their settings a tick after they are created, so the first
+  value one could report was the default rather than the persisted entry, and a
+  persisted `receiverEnabled: false` was replaced by the default on every start:
+  the helper ran, bound port 53317 and announced itself on the network. Reading
+  the entry directly also means the persisted setting and the effective setting
+  are the same value and cannot drift apart.
 - Retry a helper that exits before it is ready, on the same bounded schedule
   used for one that stops later. A port conflict skipped the retries entirely
   and reported a permanent failure on the first exit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   `service` entry point that the shell loads once, and each bar widget is a
   view onto it. The IPC target was registered once per monitor for the same
   reason, and the shell kept only the first registration.
+- Retry a helper that exits before it is ready, on the same bounded schedule
+  used for one that stops later. A port conflict skipped the retries entirely
+  and reported a permanent failure on the first exit.
+- Say what actually failed when the receiver cannot start. A taken port now
+  names port 53317 rather than advising a reinstall, which never frees it, and
+  the reinstall advice moved to the case it fixes: a helper binary that is
+  missing and never launches at all.
 
 ## 1.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Run one helper per shell session instead of one per monitor. The bar builds a
+  widget for every screen, so on a multi-monitor setup each extra copy started
+  its own helper, lost the race for the LocalSend port, and reported "Nearby
+  backend could not start" while the first copy held the port and worked. The
+  helper, the transfer state, and the `oma.nearby` IPC target now live in a
+  `service` entry point that the shell loads once, and each bar widget is a
+  view onto it. The IPC target was registered once per monitor for the same
+  reason, and the shell kept only the first registration.
+
 ## 1.0.5
 
 - Present the Nearby TLS identity when sending. LocalSend peers ask for a client

--- a/Model.js
+++ b/Model.js
@@ -95,16 +95,16 @@ function viewAfterOutgoing(hasPendingIncoming, terminalState) {
 function barEntry(config, pluginId) {
   var id = String(pluginId || "")
   if (!config || typeof config !== "object" || id === "") return null
-  var groups = []
   var layout = config.bar && typeof config.bar === "object" ? config.bar.layout : null
   var regions = ["left", "center", "right"]
   for (var r = 0; r < regions.length; r++) {
-    if (layout && Array.isArray(layout[regions[r]])) groups.push(layout[regions[r]])
-  }
-  if (Array.isArray(config.plugins)) groups.push(config.plugins)
-  for (var g = 0; g < groups.length; g++) {
-    for (var e = 0; e < groups[g].length; e++) {
-      var entry = groups[g][e]
+    var entries = layout && Array.isArray(layout[regions[r]]) ? layout[regions[r]] : []
+    for (var e = 0; e < entries.length; e++) {
+      var entry = entries[e]
+      if (typeof entry === "string") {
+        if (entry === id) return { id: id, settings: {} }
+        continue
+      }
       if (!entry || typeof entry !== "object") continue
       if (String(entry.id || "") !== id) continue
       var settings = {}
@@ -112,7 +112,49 @@ function barEntry(config, pluginId) {
       return { id: String(entry.id), settings: settings }
     }
   }
+  var plugins = Array.isArray(config.plugins) ? config.plugins : []
+  for (var p = 0; p < plugins.length; p++) {
+    var plugin = plugins[p]
+    if (!plugin || typeof plugin !== "object" || String(plugin.id || "") !== id) continue
+    var pluginSettings = {}
+    for (var pluginKey in plugin) if (pluginKey !== "id") pluginSettings[pluginKey] = plugin[pluginKey]
+    return { id: String(plugin.id), settings: pluginSettings }
+  }
   return null
+}
+
+// Quattro accepts a bare id in bar.layout, but its inline-settings writer can
+// only attach settings to object entries. Promote a matching string in place
+// before writing the first setting; top-level plugins[] does not accept this
+// form in the host and is deliberately excluded.
+function hasStringBarEntry(config, pluginId) {
+  var id = String(pluginId || "")
+  var layout = config && config.bar && typeof config.bar === "object" ? config.bar.layout : null
+  if (!layout || id === "") return false
+  var regions = ["left", "center", "right"]
+  for (var r = 0; r < regions.length; r++) {
+    var entries = Array.isArray(layout[regions[r]]) ? layout[regions[r]] : []
+    for (var e = 0; e < entries.length; e++) if (entries[e] === id) return true
+  }
+  return false
+}
+
+function promoteStringBarEntry(config, pluginId, settings) {
+  var id = String(pluginId || "")
+  var layout = config && config.bar && typeof config.bar === "object" ? config.bar.layout : null
+  if (!layout || id === "") return false
+  var regions = ["left", "center", "right"]
+  for (var r = 0; r < regions.length; r++) {
+    var entries = Array.isArray(layout[regions[r]]) ? layout[regions[r]] : []
+    for (var e = 0; e < entries.length; e++) {
+      if (entries[e] !== id) continue
+      var promoted = { id: id }
+      for (var key in settings) if (key !== "id") promoted[key] = settings[key]
+      entries[e] = promoted
+      return true
+    }
+  }
+  return false
 }
 
 // Receiving is on unless the entry says otherwise, and off until the entry
@@ -136,4 +178,4 @@ function manifestVersion(text, pluginId) {
   }
 }
 
-if (typeof module !== "undefined") module.exports = { parseLine, upsertDevice, snapshotDevices, iconFor, formatBytes, incomingSummary, enqueueIncoming, removeIncoming, currentIncoming, outgoingCommand, viewAfterOutgoing, barEntry, receiverEnabledIn, helperVersionMatches, manifestVersion }
+if (typeof module !== "undefined") module.exports = { parseLine, upsertDevice, snapshotDevices, iconFor, formatBytes, incomingSummary, enqueueIncoming, removeIncoming, currentIncoming, outgoingCommand, viewAfterOutgoing, barEntry, hasStringBarEntry, promoteStringBarEntry, receiverEnabledIn, helperVersionMatches, manifestVersion }

--- a/Model.js
+++ b/Model.js
@@ -81,6 +81,47 @@ function viewAfterOutgoing(hasPendingIncoming, terminalState) {
   return hasPendingIncoming ? "incoming" : terminalState
 }
 
+// The plugin's own entry in shell.json, or null when it is not there yet.
+//
+// The service reads its settings from the shell config rather than waiting for
+// a bar widget to hand them over. Widgets are built once per monitor and get
+// their `settings` injected a tick after they are created, so a widget cannot
+// report the persisted state at the moment it starts up, and several widgets
+// reporting the same state is redundant rather than authoritative.
+//
+// Null means "shell.json has not been applied yet", not "no settings": the
+// shell only keeps this plugin loaded while the entry exists, so an absent
+// entry is a config that has not arrived rather than one that says nothing.
+function barEntry(config, pluginId) {
+  var id = String(pluginId || "")
+  if (!config || typeof config !== "object" || id === "") return null
+  var groups = []
+  var layout = config.bar && typeof config.bar === "object" ? config.bar.layout : null
+  var regions = ["left", "center", "right"]
+  for (var r = 0; r < regions.length; r++) {
+    if (layout && Array.isArray(layout[regions[r]])) groups.push(layout[regions[r]])
+  }
+  if (Array.isArray(config.plugins)) groups.push(config.plugins)
+  for (var g = 0; g < groups.length; g++) {
+    for (var e = 0; e < groups[g].length; e++) {
+      var entry = groups[g][e]
+      if (!entry || typeof entry !== "object") continue
+      if (String(entry.id || "") !== id) continue
+      var settings = {}
+      for (var key in entry) if (key !== "id") settings[key] = entry[key]
+      return { id: String(entry.id), settings: settings }
+    }
+  }
+  return null
+}
+
+// Receiving is on unless the entry says otherwise, and off until the entry
+// exists at all, so a persisted "off" cannot be missed while the config is
+// still loading.
+function receiverEnabledIn(entry) {
+  return !!entry && entry.settings.receiverEnabled !== false
+}
+
 function helperVersionMatches(pluginVersion, helperVersion) {
   return String(pluginVersion || "") !== "" && String(pluginVersion) === String(helperVersion || "")
 }
@@ -95,4 +136,4 @@ function manifestVersion(text, pluginId) {
   }
 }
 
-if (typeof module !== "undefined") module.exports = { parseLine, upsertDevice, snapshotDevices, iconFor, formatBytes, incomingSummary, enqueueIncoming, removeIncoming, currentIncoming, outgoingCommand, viewAfterOutgoing, helperVersionMatches, manifestVersion }
+if (typeof module !== "undefined") module.exports = { parseLine, upsertDevice, snapshotDevices, iconFor, formatBytes, incomingSummary, enqueueIncoming, removeIncoming, currentIncoming, outgoingCommand, viewAfterOutgoing, barEntry, receiverEnabledIn, helperVersionMatches, manifestVersion }

--- a/Panel.qml
+++ b/Panel.qml
@@ -8,70 +8,50 @@ import "Model.js" as Model
 Panel {
   id: root
   moduleName: "oma.nearby"
-  ipcTarget: "oma.nearby"
+  // The `oma.nearby` IPC target belongs to the service, which exists once. A
+  // widget registering it would register it once per monitor.
   manageIpc: false
 
   // The host may replace moduleName with an instance id. Keep the manifest id
   // stable for registry lookups and filesystem paths.
   readonly property string manifestPluginId: "oma.nearby"
-  readonly property var manifestMetadata: bar && bar.shell
-    ? bar.shell.barWidgetRegistry.metadataFor(manifestPluginId)
+
+  // The bar builds one of these per monitor, so this file owns no helper, no
+  // transfer state, and no IPC target. All of that lives in the `service`
+  // entry point, which the shell loads exactly once; everything below is a
+  // view onto it plus this popup's own cursor. See Service.qml.
+  readonly property var engine: bar && bar.shell && typeof bar.shell.serviceFor === "function"
+    ? bar.shell.serviceFor(manifestPluginId)
     : null
-  readonly property string metadataSourceDir: manifestMetadata
-    ? String(manifestMetadata.sourceDir || "")
-    : ""
-  readonly property string pluginDir: metadataSourceDir !== ""
-    ? metadataSourceDir
-    : (Quickshell.env("HOME") || "") + "/.config/omarchy/plugins/" + manifestPluginId
-  property string pluginVersion: ""
+
   readonly property color foreground: bar ? bar.foreground : Color.foreground
   readonly property color urgent: bar ? bar.urgent : Color.urgent
   readonly property color dim: Qt.darker(foreground, 1.4)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
-  property bool backendReady: false
-  property bool receiverEnabled: setting("receiverEnabled", true) !== false
-  property bool discoveryActive: false
-  property var devices: []
-  property var selectedDevice: null
-  property string viewState: "nearby"
-  property string statusText: "Starting receiver…"
-  property string errorText: ""
+
+  // Engine state, read under the names the popup already used. A view with no
+  // engine says so rather than rendering an empty panel.
+  readonly property bool backendReady: engine ? engine.backendReady : false
+  readonly property bool receiverEnabled: engine ? engine.receiverEnabled : false
+  readonly property bool discoveryActive: engine ? engine.discoveryActive : false
+  readonly property var devices: engine ? engine.devices : []
+  readonly property var selectedDevice: engine ? engine.selectedDevice : null
+  readonly property string viewState: engine ? engine.viewState : "nearby"
+  readonly property string statusText: engine ? engine.statusText : "Nearby engine is not loaded."
+  readonly property string errorText: engine ? engine.errorText : "Nearby engine is not loaded."
+  readonly property var incomingQueue: engine ? engine.incomingQueue : []
+  readonly property var incoming: engine ? engine.incoming : null
+  readonly property string incomingText: engine ? engine.incomingText : ""
+  readonly property real progress: engine ? engine.progress : 0
+  readonly property string transferName: engine ? engine.transferName : ""
+  readonly property string transferPeer: engine ? engine.transferPeer : ""
+  readonly property string pinError: engine ? engine.pinError : ""
+
+  // Cursor and popup focus are per monitor, so they stay here.
   property int selectedIndex: 0
   property bool cursorActive: false
-  property var incomingQueue: []
-  readonly property var incoming: Model.currentIncoming(incomingQueue)
-  property string incomingText: ""
-  property bool incomingTextPending: false
-  property string lastReceivedPath: ""
-  property real progress: 0
-  property string transferName: ""
-  property string transferPeer: ""
-  property string activeIncomingSession: ""
-  property string outgoingTransferId: ""
-  property var pendingOutgoing: null
-  property string pinError: ""
-  property int transferSequence: 0
   property int nearbyPhraseIndex: 0
-  property bool shutdownPending: false
-  property bool backendAcceptedThisRun: false
-  property bool backendVersionMismatch: false
-
-  FileView {
-    path: root.pluginDir + "/manifest.json"
-    printErrors: false
-    onLoaded: {
-      root.pluginVersion = Model.manifestVersion(text(), root.manifestPluginId)
-      if (root.pluginVersion === "") {
-        root.errorText = "Nearby manifest version unavailable."
-        root.statusText = root.errorText
-      }
-    }
-    onLoadFailed: function(error) {
-      root.pluginVersion = ""
-      root.errorText = "Nearby manifest version unavailable."
-      root.statusText = root.errorText
-    }
-  }
+  property bool viewRegistered: false
 
   readonly property var nearbyPhrases: [
     "Looking nearby",
@@ -95,136 +75,54 @@ Panel {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
-  IpcHandler {
-    target: root.ipcTarget
-    function open(): string { root.open(); return "ok" }
-    function close(): string { root.close(); return "ok" }
-    function toggle(): string { root.toggle(); return "ok" }
-    function receiverOn(): string { if (!root.receiverEnabled) root.toggleReceiver(); return "ok" }
-    function receiverOff(): string { if (root.receiverEnabled) root.toggleReceiver(); return "ok" }
-    function receiverToggle(): string { root.toggleReceiver(); return "ok" }
-    function status(): string { return JSON.stringify({enabled:root.receiverEnabled,ready:root.backendReady,running:backend.running,devices:root.devices.length}) }
+  // Settings arrive per widget; the engine keeps the copy it persists against.
+  function pushSettings() {
+    if (engine && typeof engine.configure === "function") engine.configure(moduleName, settings)
+  }
+  onSettingsChanged: pushSettings()
+  Component.onCompleted: { pushSettings(); syncOpenState() }
+
+  // Discovery follows the popup and there is one popup per monitor, so the
+  // engine counts open views instead of tracking a single flag.
+  function syncOpenState() {
+    if (!engine || opened === viewRegistered) return
+    viewRegistered = opened
+    if (opened) engine.viewOpened()
+    else engine.viewClosed()
+  }
+  onEngineChanged: { viewRegistered = false; pushSettings(); syncOpenState() }
+  Component.onDestruction: if (engine && viewRegistered) engine.viewClosed()
+
+  Connections {
+    target: root.engine
+    function onCursorRequested(index) { root.selectedIndex = index }
+    function onPinCleared() { pinInput.text = "" }
+    function onPinFocusRequested() { if (root.opened) Qt.callLater(function(){ pinInput.forceActiveFocus() }) }
+    function onFocusRestoreRequested() { if (root.opened) Qt.callLater(function(){ keyCatcher.forceActiveFocus() }) }
   }
 
-  function send(command) {
-    if (!backend.running) return
-    backend.write(JSON.stringify(command) + "\n")
-  }
-  function persistReceiverEnabled(enabled) {
-    receiverEnabled = enabled
-    settings = Object.assign({}, settings, { receiverEnabled: enabled })
-    if (bar && bar.shell) bar.shell.updateEntryInline(moduleName, settings)
-  }
-  function toggleReceiver() {
-    if (shutdownPending) return
-    var enable = !receiverEnabled
-    backendRestart.stop()
-    if (enable) {
-      persistReceiverEnabled(true)
-      errorText = ""
-      statusText = "Starting receiver…"
-    } else {
-      stopDiscovery()
-      shutdownPending = true
-      send({command:"shutdown"})
-      receiverShutdownFallback.restart()
-    }
-  }
-  function finishReceiverShutdown() {
-    receiverShutdownFallback.stop()
-    shutdownPending = false
-    persistReceiverEnabled(false)
-    backendReady = false
-    devices = []
-    selectedDevice = null
-    incomingQueue = []
-    incomingTextPending = false
-    activeIncomingSession = ""
-    clearPendingOutgoing()
-    viewState = "nearby"
-    statusText = "Turned off"
-    errorText = ""
-  }
-  function startDiscovery() { discoveryActive = true; errorText = ""; statusText = devices.length ? "Ready" : "Looking nearby…"; send({command:"discovery_start"}) }
-  function forceFullDiscovery() { discoveryActive = true; errorText = ""; statusText = "Scanning local network…"; send({command:"discovery_start",force_full:true}) }
-  function stopDiscovery() { discoveryActive = false; send({command:"discovery_stop"}) }
-  function chooseDevice(index) { if (index >= 0 && index < devices.length) { selectedDevice = devices[index]; viewState = "target"; selectedIndex = 0 } }
-  function goBack() { if (viewState === "pin") cancelPin(); else if (viewState === "target") { viewState = "nearby"; selectedDevice = null; selectedIndex = 0 } else close() }
-  function failWith(message) { viewState="error"; errorText=message; statusText=errorText }
+  function toggleReceiver() { if (engine) engine.toggleReceiver() }
+  function startDiscovery() { if (engine) engine.startDiscovery() }
+  function forceFullDiscovery() { if (engine) engine.forceFullDiscovery() }
+  function chooseDevice(index) { if (engine) engine.chooseDevice(index) }
+  function acceptIncoming() { if (engine) engine.acceptIncoming() }
+  function declineIncoming() { if (engine) engine.declineIncoming() }
+  function finishText() { if (engine) engine.finishText() }
+  function finishTerminal() { if (engine) engine.finishTerminal() }
+  function cancelOutgoing() { if (engine) engine.cancelOutgoing() }
+  function cancelPin() { if (engine) engine.cancelPin() }
+  function retryWithPin() { if (engine) engine.retryWithPin(String(pinInput.text || "")) }
+  function failWith(message) { if (engine) engine.failWith(message) }
+  function noteTextCopied() { if (engine) engine.noteTextCopied() }
+  function beginOutgoing(pending) { if (engine) engine.beginOutgoing(pending) }
+  function goBack() { if (viewState === "pin") cancelPin(); else if (viewState === "target") { if (engine) engine.clearTarget() } else close() }
+
+  // The chooser and the clipboard belong to the monitor the user acted on, so
+  // they stay with the view and hand their result to the engine.
   function selectFiles() { if (!selectedDevice || picker.running) return; picker.launched=false; picker.running = true }
   function sendClipboard() { if (!selectedDevice || clipboard.running) return; clipboard.launched=false; clipboard.running = true }
   function copyReceivedText() { clipboardWriter.launched=false; clipboardWriter.running=true }
-  function clearPendingOutgoing() { pendingOutgoing=null; outgoingTransferId=""; pinError=""; pinInput.text="" }
-  function dispatchPendingOutgoing(pin) {
-    if (!pendingOutgoing) return
-    transferSequence++
-    outgoingTransferId="out-"+Date.now()+"-"+transferSequence
-    var command=Model.outgoingCommand(pendingOutgoing,outgoingTransferId,pin)
-    if (!command) { clearPendingOutgoing(); viewState="error"; errorText="Transfer failed"; return }
-    pinInput.text=""
-    pinError=""
-    send(command)
-  }
-  function beginOutgoing(pending) { if(pendingOutgoing||!backend.running)return; pendingOutgoing=pending; dispatchPendingOutgoing(null) }
-  function retryWithPin() {
-    if (outgoingTransferId !== "") return
-    var pin=String(pinInput.text || "")
-    if (pin === "") { pinError="Enter the receiver PIN"; pinInput.forceActiveFocus(); return }
-    dispatchPendingOutgoing(pin)
-  }
-  function showPinPrompt(message) {
-    outgoingTransferId=""
-    viewState="pin"
-    pinError=message
-    statusText="PIN required"
-    Qt.callLater(function(){pinInput.forceActiveFocus()})
-  }
-  function cancelPin() { if(outgoingTransferId!=="")send({command:"cancel_outgoing",transfer_id:outgoingTransferId}); clearPendingOutgoing(); if(incoming){viewState="incoming";selectedIndex=1}else if(incomingTextPending){incomingTextPending=false;viewState="text";statusText="Text received";selectedIndex=0}else{viewState=selectedDevice?"target":"nearby";selectedIndex=0} Qt.callLater(function(){keyCatcher.forceActiveFocus()}) }
-  function acceptIncoming() { if (!incoming) return; send({command:"accept",request_id:incoming.requestId}); viewState="receiving"; transferPeer=incoming.sender; transferName=Model.incomingSummary(incoming.files); progress=0 }
-  function declineIncoming() {
-    if (!incoming) return
-    var requestId = incoming.requestId
-    send({command:"decline",request_id:requestId})
-    incomingQueue = Model.removeIncoming(incomingQueue, requestId)
-    if (!incoming&&incomingTextPending) { incomingTextPending=false; viewState="text"; statusText="Text received" }
-    else { viewState = incoming ? "incoming" : "nearby"; statusText = incoming ? "Incoming transfer" : "Declined" }
-    selectedIndex = incoming ? 1 : 0
-  }
-  function finishIncoming(terminalState, message, completed) {
-    activeIncomingSession = ""
-    if (pendingOutgoing) return
-    if (incoming) {
-      viewState = "incoming"
-      selectedIndex = 1
-      statusText = "Incoming transfer"
-      errorText = ""
-      progress = 0
-      return
-    }
-    if (incomingTextPending) { incomingTextPending=false; viewState="text"; statusText="Text received"; errorText=""; progress=0; return }
-    viewState = terminalState
-    statusText = message
-    errorText = terminalState === "error" ? message : ""
-    if (completed) progress = 1
-  }
-  function finishOutgoing(terminalState, message, completed) {
-    clearPendingOutgoing()
-    if (incoming) {
-      viewState = Model.viewAfterOutgoing(true, terminalState)
-      selectedIndex = 1
-      statusText = "Incoming transfer"
-      errorText = ""
-      progress = 0
-      return
-    }
-    if (incomingTextPending) { incomingTextPending=false; viewState="text"; statusText="Text received"; errorText=""; progress=0; return }
-    viewState = Model.viewAfterOutgoing(false, terminalState)
-    statusText = message
-    errorText = terminalState === "error" ? message : ""
-    if (completed) progress = 1
-  }
-  function finishText() { incomingText=""; incomingTextPending=false; viewState="nearby"; selectedIndex=0; startDiscovery() }
-  function finishTerminal() { viewState="nearby"; selectedIndex=0; startDiscovery() }
+
   function moveCursor(dx, dy) {
     cursorActive = true
     if (viewState === "nearby") {
@@ -239,99 +137,17 @@ Panel {
     else if (viewState === "target") selectedIndex === 0 ? selectFiles() : sendClipboard()
     else if (viewState === "incoming") selectedIndex === 0 ? declineIncoming() : acceptIncoming()
     else if (viewState === "text") { if(selectedIndex===0)copyReceivedText(); else finishText() }
-    else if (viewState === "sending") send({command:"cancel_outgoing",transfer_id:outgoingTransferId})
+    else if (viewState === "sending") cancelOutgoing()
     else if (viewState === "success" || viewState === "error") finishTerminal()
-  }
-  function handleBackendExit(code) {
-    backendReady=false; discoveryActive=false; incomingQueue=[]; incomingTextPending=false; activeIncomingSession=""; clearPendingOutgoing()
-    if (shutdownPending) { finishReceiverShutdown(); return }
-    if (!receiverEnabled) { statusText="Turned off"; errorText=""; return }
-    if (backendVersionMismatch) return
-    if (!backendAcceptedThisRun) {
-      errorText="Nearby backend could not start. Run the Nearby installer again or build it with ./build.sh."
-      statusText=errorText
-      return
-    }
-    errorText=code===0 ? "Receiver stopped" : "Receiver unavailable"
-    statusText=errorText
-    if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; errorText="Nearby backend stopped during transfer"; statusText=errorText }
-    if (backendRestart.attempts < 4) { backendRestart.attempts++; backendRestart.interval=Math.min(30000,1000*Math.pow(2,backendRestart.attempts-1)); backendRestart.restart() }
-  }
-  function handleEvent(event) {
-    if (!event || !event.event) return
-    if (backendVersionMismatch && event.event !== "ready") return
-    if (event.event === "ready") {
-      if (!Model.helperVersionMatches(pluginVersion, event.helperVersion)) {
-        backendReady=false
-        backendVersionMismatch=true
-        errorText="Nearby backend version mismatch. Run the Nearby installer again."
-        statusText=errorText
-        send({command:"shutdown"})
-        return
-      }
-      backendAcceptedThisRun=true; backendReady=true; backendVersionMismatch=false; backendRestart.attempts=0; statusText="Ready to receive"; errorText=""; if(opened&&viewState==="nearby")startDiscovery()
-    }
-    else if (event.event === "peer_snapshot") { devices=Model.snapshotDevices(event.devices); statusText=devices.length ? "Ready" : "Looking nearby…" }
-    else if (event.event === "device") { devices=Model.upsertDevice(devices,event.device); statusText=devices.length ? "Ready" : "Looking nearby…" }
-    else if (event.event === "discovery_started") discoveryActive=true
-    else if (event.event === "discovery_stopped") discoveryActive=false
-    else if (event.event === "incoming_request") {
-      incomingQueue=Model.enqueueIncoming(incomingQueue,event); if(!incomingTextPending)incomingText=""; if (viewState!=="sending" && viewState!=="receiving" && viewState!=="pin") { viewState="incoming"; selectedIndex=1 }
-      Quickshell.execDetached(["notify-send","-a","Nearby","Incoming transfer",String(event.sender)+" wants to send "+Model.incomingSummary(event.files)])
-    }
-    else if (event.event === "incoming_text") {
-      incomingText=String(event.text || ""); transferPeer=String(event.sender || ""); incomingTextPending=pendingOutgoing!==null; if (!pendingOutgoing) { viewState="text"; stopDiscovery() }
-      Quickshell.execDetached(["notify-send","-a","Nearby","Text received","From "+String(event.sender || "")])
-    }
-    else if (event.event === "incoming_accepted") { incomingQueue=Model.removeIncoming(incomingQueue,event.requestId) }
-    else if (event.event === "incoming_expired") {
-      var expiredWasCurrent=incoming&&incoming.requestId===event.requestId
-      incomingQueue=Model.removeIncoming(incomingQueue,event.requestId)
-      if (expiredWasCurrent&&(viewState==="incoming"||(viewState==="receiving"&&activeIncomingSession===""))) {
-        if (incoming) { statusText="Incoming transfer"; selectedIndex=1 }
-        else if (incomingTextPending) { incomingTextPending=false; viewState="text"; statusText="Text received"; errorText="" }
-        else { viewState="error"; errorText="Transfer request expired"; statusText=errorText }
-      }
-    }
-    else if (event.event === "incoming_progress") { if(activeIncomingSession===""){if(viewState!=="receiving")return;activeIncomingSession=String(event.sessionId)} if(activeIncomingSession!==String(event.sessionId))return; if(pendingOutgoing)return; viewState="receiving"; transferName=String(event.name); transferPeer=String(event.sender); progress=event.total>0 ? event.bytes/event.total : 0 }
-    else if (event.event === "file_received") { if(activeIncomingSession===""){if(viewState!=="receiving")return;activeIncomingSession=String(event.sessionId)} if(activeIncomingSession!==String(event.sessionId))return; lastReceivedPath=String(event.path); if(pendingOutgoing)return; transferName=String(event.name); transferPeer=String(event.sender) }
-    else if (event.event === "incoming_done") { if(activeIncomingSession!==String(event.sessionId))return; finishIncoming("success","Received",true) }
-    else if (event.event === "incoming_cancelled") { if(activeIncomingSession===""){if(viewState!=="receiving")return;activeIncomingSession=String(event.sessionId)} if(activeIncomingSession!==String(event.sessionId))return; finishIncoming("error","Transfer cancelled",false) }
-    else if (event.event === "incoming_failed") { if(activeIncomingSession===""){if(viewState!=="receiving")return;activeIncomingSession=String(event.sessionId)} if(activeIncomingSession!==String(event.sessionId))return; finishIncoming("error",String(event.message||"Transfer failed"),false) }
-    else if (event.event === "incoming_declined") { incomingQueue=Model.removeIncoming(incomingQueue,event.requestId) }
-    else if (event.event === "outgoing_preparing") { if(String(event.transferId)!==outgoingTransferId)return; viewState="sending"; transferName=String(event.name); transferPeer=String(event.target); progress=0; stopDiscovery() }
-    else if (event.event === "outgoing_progress") { if(String(event.transferId)!==outgoingTransferId)return; viewState="sending"; progress=event.total>0 ? event.bytes/event.total : 0 }
-    else if (event.event === "outgoing_done") { if(String(event.transferId)!==outgoingTransferId)return; finishOutgoing("success", "Sent", true) }
-    else if (event.event === "outgoing_cancelled") { if(String(event.transferId)!==outgoingTransferId)return; finishOutgoing("error", "Transfer cancelled", false) }
-    else if (event.event === "outgoing_pin_required") { if(String(event.transferId)!==outgoingTransferId)return; showPinPrompt("") }
-    else if (event.event === "outgoing_invalid_pin") { if(String(event.transferId)!==outgoingTransferId)return; showPinPrompt("Incorrect PIN") }
-    else if (event.event === "outgoing_failed") { if(event.transferId && String(event.transferId)!==outgoingTransferId)return; finishOutgoing("error", String(event.message||"Transfer failed"), false) }
-    else if (event.event === "error") { viewState="error"; errorText=String(event.message||"Transfer failed"); statusText=errorText }
   }
 
   onOpenedChanged: {
     if (opened) {
       cursorActive=false; selectedIndex=-1; nearbyPhraseIndex=0
-      if (viewState === "nearby" && receiverEnabled && backendReady) startDiscovery()
-      Qt.callLater(function(){ if (viewState==="pin") pinInput.forceActiveFocus(); else keyCatcher.forceActiveFocus() })
-    } else { stopDiscovery() }
+      syncOpenState()
+      Qt.callLater(function(){ if (root.viewState==="pin") pinInput.forceActiveFocus(); else keyCatcher.forceActiveFocus() })
+    } else { syncOpenState() }
   }
-
-  Process {
-    id: backend
-    command: [root.pluginDir + "/bin/omarchy-nearby-helper"]
-    running: root.receiverEnabled && root.pluginVersion !== ""
-    stdinEnabled: true
-    stdout: SplitParser { onRead: function(line) { root.handleEvent(Model.parseLine(line)) } }
-    stderr: SplitParser { onRead: function(line) { console.warn("nearby backend", line) } }
-    onStarted: {
-      root.backendAcceptedThisRun=false
-      root.backendVersionMismatch=false
-    }
-    onExited: function(code) { root.handleBackendExit(code) }
-  }
-  Timer { id: backendRestart; property int attempts: 0; interval: 1000; repeat: false; onTriggered: if (root.receiverEnabled && !backend.running) backend.running=true }
-  Timer { id: receiverShutdownFallback; interval: 250; repeat: false; onTriggered: root.finishReceiverShutdown() }
 
   Timer {
     id: nearbyPhraseTimer
@@ -493,7 +309,7 @@ Panel {
           Text { width:parent.width; textFormat:Text.PlainText; text:root.transferName; color:root.foreground; font.family:root.fontFamily; font.pixelSize:Style.font.title; font.bold:true; elide:Text.ElideMiddle }
           Rectangle { width:parent.width; height:Style.space(4); radius:height/2; color:Qt.darker(root.foreground,2.2); Rectangle { width:parent.width*Math.max(0,Math.min(1,root.progress)); height:parent.height; radius:height/2; color:root.foreground; Behavior on width { NumberAnimation { duration:120 } } } }
           Text { text:Math.round(root.progress*100)+"% · "+(root.viewState==="sending"?"to ":"from ")+root.transferPeer; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body }
-          Button { visible:root.viewState==="sending"; text:"Cancel"; bordered:true; foreground:root.urgent; hasCursor:root.cursorActive; onClicked:root.send({command:"cancel_outgoing",transfer_id:root.outgoingTransferId}) }
+          Button { visible:root.viewState==="sending"; text:"Cancel"; bordered:true; foreground:root.urgent; hasCursor:root.cursorActive; onClicked:root.cancelOutgoing() }
         }
 
         Column {
@@ -524,6 +340,6 @@ Panel {
     stdinEnabled: true
     onStarted: { clipboardWriter.launched=true; write(root.incomingText); stdinEnabled=false }
     onRunningChanged: if (!running && !clipboardWriter.launched && root.viewState==="text") root.failWith("wl-copy is required to copy received text")
-    onExited: function(code) { stdinEnabled=true; if(root.viewState!=="text")return; if(code===0){root.viewState="success";root.statusText="Received"} else root.failWith("wl-copy is required to copy received text") }
+    onExited: function(code) { stdinEnabled=true; if(root.viewState!=="text")return; if(code===0){root.noteTextCopied()} else root.failWith("wl-copy is required to copy received text") }
   }
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -75,12 +75,7 @@ Panel {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
-  // Settings arrive per widget; the engine keeps the copy it persists against.
-  function pushSettings() {
-    if (engine && typeof engine.configure === "function") engine.configure(moduleName, settings)
-  }
-  onSettingsChanged: pushSettings()
-  Component.onCompleted: { pushSettings(); syncOpenState() }
+  Component.onCompleted: syncOpenState()
 
   // Discovery follows the popup and there is one popup per monitor, so the
   // engine counts open views instead of tracking a single flag.
@@ -90,7 +85,7 @@ Panel {
     if (opened) engine.viewOpened()
     else engine.viewClosed()
   }
-  onEngineChanged: { viewRegistered = false; pushSettings(); syncOpenState() }
+  onEngineChanged: { viewRegistered = false; syncOpenState() }
   Component.onDestruction: if (engine && viewRegistered) engine.viewClosed()
 
   Connections {

--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ that are older than 24 hours.
 ## Architecture
 
 ```text
-Quickshell UI (Panel.qml)
+Bar widget (Panel.qml)      one per monitor, view only
+        │
+        │  reads state, calls methods
+        ▼
+Nearby engine (Service.qml) one per shell session
         │
         ├── Model.js
         │
@@ -99,6 +103,12 @@ Quickshell UI (Panel.qml)
                  ▼
         LocalSend-compatible LAN peer
 ```
+
+The bar builds one widget per screen, while the helper binds a single
+LocalSend port and the `oma.nearby` IPC target can only be registered once. The
+engine is therefore a `service` entry point, which the shell loads once per
+session, and every bar widget is a view onto it holding nothing but its own
+cursor and popup.
 
 The Rust helper vendors a modified `localsend-rs` library. See
 `THIRD_PARTY_NOTICES.md` for attribution and licensing information, and
@@ -185,6 +195,8 @@ Frontend model tests:
 
 ```sh
 node tests/model.test.js
+node tests/panel-state.test.js
+node tests/service-state.test.js
 ```
 
 Backend tests:

--- a/ROBUSTNESS.md
+++ b/ROBUSTNESS.md
@@ -8,6 +8,8 @@ Run:
 cargo test --manifest-path backend/Cargo.toml
 cargo test --manifest-path backend/vendor/localsend-rs/Cargo.toml --features https
 node tests/model.test.js
+node tests/panel-state.test.js
+node tests/service-state.test.js
 ```
 
 The suites cover peer registry retention/expiry, command correlation, request decisions,

--- a/Service.qml
+++ b/Service.qml
@@ -149,6 +149,7 @@ Item {
     var enable = !receiverEnabled
     backendRestart.stop()
     if (enable) {
+      backendRestart.attempts = 0
       persistReceiverEnabled(true)
       errorText = ""
       statusText = "Starting receiver…"
@@ -259,13 +260,20 @@ Item {
     if (!receiverEnabled) { statusText="Turned off"; errorText=""; return }
     if (backendVersionMismatch) return
     if (!backendAcceptedThisRun) {
-      errorText="Nearby backend could not start. Run the Nearby installer again or build it with ./build.sh."
+      // The helper ran and left before announcing itself. It reports the
+      // reason on stderr; the one a user can act on is a port already taken by
+      // another LocalSend receiver. Retry on the same bounded schedule as a
+      // receiver that dropped later, so a port that frees up is picked back up
+      // and a port that never does stops after four attempts.
+      errorText = backendRestart.attempts < 4
+        ? "Nearby receiver could not start. Retrying…"
+        : "Nearby receiver could not start. Another LocalSend app may be holding port 53317."
       statusText=errorText
-      return
+    } else {
+      errorText=code===0 ? "Receiver stopped" : "Receiver unavailable"
+      statusText=errorText
+      if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; errorText="Nearby backend stopped during transfer"; statusText=errorText }
     }
-    errorText=code===0 ? "Receiver stopped" : "Receiver unavailable"
-    statusText=errorText
-    if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; errorText="Nearby backend stopped during transfer"; statusText=errorText }
     if (backendRestart.attempts < 4) { backendRestart.attempts++; backendRestart.interval=Math.min(30000,1000*Math.pow(2,backendRestart.attempts-1)); backendRestart.restart() }
   }
   function handleEvent(event) {
@@ -322,14 +330,31 @@ Item {
 
   Process {
     id: backend
+    property bool launched: false
     command: [root.pluginDir + "/bin/omarchy-nearby-helper"]
     running: root.receiverEnabled && root.pluginVersion !== ""
     stdinEnabled: true
     stdout: SplitParser { onRead: function(line) { root.handleEvent(Model.parseLine(line)) } }
     stderr: SplitParser { onRead: function(line) { console.warn("nearby backend", line) } }
     onStarted: {
+      backend.launched=true
       root.backendAcceptedThisRun=false
       root.backendVersionMismatch=false
+    }
+    // A helper that is missing rather than failing never reaches onExited:
+    // Quickshell returns running to false without an exit code, the same way
+    // the file chooser and clipboard readers report a command that never ran.
+    // This is the case reinstalling actually fixes.
+    onRunningChanged: {
+      if (running) { backend.launched=false; return }
+      if (backend.launched) return
+      // `running` is a binding, so it also drops when the receiver is turned
+      // off or the manifest version goes away. Only a helper we still want
+      // running counts as one that failed to launch.
+      if (!root.receiverEnabled || root.pluginVersion === "") return
+      root.backendReady=false
+      root.errorText="Nearby helper is missing. Run the Nearby installer again or build it with ./build.sh."
+      root.statusText=root.errorText
     }
     onExited: function(code) { root.handleBackendExit(code) }
   }

--- a/Service.qml
+++ b/Service.qml
@@ -1,0 +1,338 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "Model.js" as Model
+
+// One Nearby engine per shell session, not one per monitor.
+//
+// The bar instantiates its widgets once per screen (Variants over
+// Quickshell.screens), so a helper owned by the widget was started once per
+// monitor. The helper binds the LocalSend port, so on a second monitor every
+// instance after the first lost the race and exited with EADDRINUSE, leaving
+// that bar reporting a receiver that could not start while another copy held
+// the port. Registering the IPC target that many times had the same problem:
+// only the first registration was used.
+//
+// The shell loads a `service` kind exactly once, so the helper, the transfer
+// state, and the IPC target live here. Every bar widget is a view onto this
+// object and owns nothing but its own cursor and popup.
+Item {
+  id: root
+
+  // Injected by the shell when the service is created.
+  property var shell: null
+  property var manifest: null
+  property string omarchyPath: Quickshell.env("OMARCHY_PATH") || ""
+
+  readonly property string manifestPluginId: "oma.nearby"
+  readonly property string metadataSourceDir: manifest && manifest.__sourceDir
+    ? String(manifest.__sourceDir)
+    : ""
+  readonly property string pluginDir: metadataSourceDir !== ""
+    ? metadataSourceDir
+    : (Quickshell.env("HOME") || "") + "/.config/omarchy/plugins/" + manifestPluginId
+
+  // The bar entry a widget was configured from. Settings persist against this
+  // id, which the host may have replaced with an instance id.
+  property string moduleEntryId: manifestPluginId
+  property var pluginSettings: ({})
+  property bool receiverConfigured: false
+
+  property string pluginVersion: ""
+  property bool backendReady: false
+  property bool receiverEnabled: true
+  property bool discoveryActive: false
+  property var devices: []
+  property var selectedDevice: null
+  property string viewState: "nearby"
+  property string statusText: "Starting receiver…"
+  property string errorText: ""
+  property var incomingQueue: []
+  readonly property var incoming: Model.currentIncoming(incomingQueue)
+  property string incomingText: ""
+  property bool incomingTextPending: false
+  property string lastReceivedPath: ""
+  property real progress: 0
+  property string transferName: ""
+  property string transferPeer: ""
+  property string activeIncomingSession: ""
+  property string outgoingTransferId: ""
+  property var pendingOutgoing: null
+  property string pinError: ""
+  property int transferSequence: 0
+  property bool shutdownPending: false
+  property bool backendAcceptedThisRun: false
+  property bool backendVersionMismatch: false
+
+  // Discovery follows the popup, and the popup exists once per monitor, so
+  // openness is a count rather than a flag: discovery runs while any view is
+  // open and stops when the last one closes.
+  property int openViewCount: 0
+  readonly property bool anyViewOpen: openViewCount > 0
+  readonly property bool backendRunning: backend.running
+
+  // Views own their cursor and their PIN field; the engine only asks. A single
+  // engine driving several popups cannot reach into any one of them.
+  signal cursorRequested(int index)
+  signal pinCleared()
+  signal pinFocusRequested()
+  signal focusRestoreRequested()
+
+  FileView {
+    path: root.pluginDir + "/manifest.json"
+    printErrors: false
+    onLoaded: {
+      root.pluginVersion = Model.manifestVersion(text(), root.manifestPluginId)
+      if (root.pluginVersion === "") {
+        root.errorText = "Nearby manifest version unavailable."
+        root.statusText = root.errorText
+      }
+    }
+    onLoadFailed: function(error) {
+      root.pluginVersion = ""
+      root.errorText = "Nearby manifest version unavailable."
+      root.statusText = root.errorText
+    }
+  }
+
+  // Registered once, from the one object there is one of. Registering this
+  // from the widget meant one handler per monitor, of which the shell kept the
+  // first and warned about the rest.
+  //
+  // Opening a popup is still the widget's job, so those calls are handed back
+  // to the shell, which routes them through the bar to the focused monitor
+  // rather than to whichever instance had claimed the target.
+  function summonView(action) {
+    if (!shell || typeof shell[action] !== "function") return "unknown"
+    return shell[action](manifestPluginId, "{}") === false ? "unknown" : "ok"
+  }
+
+  IpcHandler {
+    target: "oma.nearby"
+    function open(): string { return root.summonView("summon") }
+    function close(): string { return root.summonView("hide") }
+    function toggle(): string { return root.summonView("toggle") }
+    function receiverOn(): string { if (!root.receiverEnabled) root.toggleReceiver(); return "ok" }
+    function receiverOff(): string { if (root.receiverEnabled) root.toggleReceiver(); return "ok" }
+    function receiverToggle(): string { root.toggleReceiver(); return "ok" }
+    function status(): string { return JSON.stringify({enabled:root.receiverEnabled,ready:root.backendReady,running:backend.running,devices:root.devices.length}) }
+  }
+
+  function configure(entryId, settings) {
+    if (String(entryId || "") !== "") moduleEntryId = String(entryId)
+    pluginSettings = settings || {}
+    if (receiverConfigured) return
+    receiverConfigured = true
+    receiverEnabled = pluginSettings.receiverEnabled !== false
+  }
+  function viewOpened() {
+    openViewCount++
+    if (openViewCount !== 1) return
+    if (viewState === "nearby" && receiverEnabled && backendReady) startDiscovery()
+  }
+  function viewClosed() {
+    if (openViewCount > 0) openViewCount--
+    if (openViewCount === 0) stopDiscovery()
+  }
+
+  function send(command) {
+    if (!backend.running) return
+    backend.write(JSON.stringify(command) + "\n")
+  }
+  function persistReceiverEnabled(enabled) {
+    receiverEnabled = enabled
+    pluginSettings = Object.assign({}, pluginSettings, { receiverEnabled: enabled })
+    if (shell) shell.updateEntryInline(moduleEntryId, pluginSettings)
+  }
+  function toggleReceiver() {
+    if (shutdownPending) return
+    var enable = !receiverEnabled
+    backendRestart.stop()
+    if (enable) {
+      persistReceiverEnabled(true)
+      errorText = ""
+      statusText = "Starting receiver…"
+    } else {
+      stopDiscovery()
+      shutdownPending = true
+      send({command:"shutdown"})
+      receiverShutdownFallback.restart()
+    }
+  }
+  function finishReceiverShutdown() {
+    receiverShutdownFallback.stop()
+    shutdownPending = false
+    persistReceiverEnabled(false)
+    backendReady = false
+    devices = []
+    selectedDevice = null
+    incomingQueue = []
+    incomingTextPending = false
+    activeIncomingSession = ""
+    clearPendingOutgoing()
+    viewState = "nearby"
+    statusText = "Turned off"
+    errorText = ""
+  }
+  function startDiscovery() { discoveryActive = true; errorText = ""; statusText = devices.length ? "Ready" : "Looking nearby…"; send({command:"discovery_start"}) }
+  function forceFullDiscovery() { discoveryActive = true; errorText = ""; statusText = "Scanning local network…"; send({command:"discovery_start",force_full:true}) }
+  function stopDiscovery() { discoveryActive = false; send({command:"discovery_stop"}) }
+  function chooseDevice(index) { if (index >= 0 && index < devices.length) { selectedDevice = devices[index]; viewState = "target"; cursorRequested(0) } }
+  function clearTarget() { viewState = "nearby"; selectedDevice = null; cursorRequested(0) }
+  function failWith(message) { viewState="error"; errorText=message; statusText=errorText }
+  function cancelOutgoing() { send({command:"cancel_outgoing",transfer_id:outgoingTransferId}) }
+  function noteTextCopied() { if (viewState !== "text") return; viewState="success"; statusText="Received" }
+  function clearPendingOutgoing() { pendingOutgoing=null; outgoingTransferId=""; pinError=""; pinCleared() }
+  function dispatchPendingOutgoing(pin) {
+    if (!pendingOutgoing) return
+    transferSequence++
+    outgoingTransferId="out-"+Date.now()+"-"+transferSequence
+    var command=Model.outgoingCommand(pendingOutgoing,outgoingTransferId,pin)
+    if (!command) { clearPendingOutgoing(); viewState="error"; errorText="Transfer failed"; return }
+    pinCleared()
+    pinError=""
+    send(command)
+  }
+  function beginOutgoing(pending) { if(pendingOutgoing||!backend.running)return; pendingOutgoing=pending; dispatchPendingOutgoing(null) }
+  function retryWithPin(pin) {
+    if (outgoingTransferId !== "") return
+    var entered=String(pin || "")
+    if (entered === "") { pinError="Enter the receiver PIN"; pinFocusRequested(); return }
+    dispatchPendingOutgoing(entered)
+  }
+  function showPinPrompt(message) {
+    outgoingTransferId=""
+    viewState="pin"
+    pinError=message
+    statusText="PIN required"
+    pinFocusRequested()
+  }
+  function cancelPin() { if(outgoingTransferId!=="")send({command:"cancel_outgoing",transfer_id:outgoingTransferId}); clearPendingOutgoing(); if(incoming){viewState="incoming";cursorRequested(1)}else if(incomingTextPending){incomingTextPending=false;viewState="text";statusText="Text received";cursorRequested(0)}else{viewState=selectedDevice?"target":"nearby";cursorRequested(0)} focusRestoreRequested() }
+  function acceptIncoming() { if (!incoming) return; send({command:"accept",request_id:incoming.requestId}); viewState="receiving"; transferPeer=incoming.sender; transferName=Model.incomingSummary(incoming.files); progress=0 }
+  function declineIncoming() {
+    if (!incoming) return
+    var requestId = incoming.requestId
+    send({command:"decline",request_id:requestId})
+    incomingQueue = Model.removeIncoming(incomingQueue, requestId)
+    if (!incoming&&incomingTextPending) { incomingTextPending=false; viewState="text"; statusText="Text received" }
+    else { viewState = incoming ? "incoming" : "nearby"; statusText = incoming ? "Incoming transfer" : "Declined" }
+    cursorRequested(incoming ? 1 : 0)
+  }
+  function finishIncoming(terminalState, message, completed) {
+    activeIncomingSession = ""
+    if (pendingOutgoing) return
+    if (incoming) {
+      viewState = "incoming"
+      cursorRequested(1)
+      statusText = "Incoming transfer"
+      errorText = ""
+      progress = 0
+      return
+    }
+    if (incomingTextPending) { incomingTextPending=false; viewState="text"; statusText="Text received"; errorText=""; progress=0; return }
+    viewState = terminalState
+    statusText = message
+    errorText = terminalState === "error" ? message : ""
+    if (completed) progress = 1
+  }
+  function finishOutgoing(terminalState, message, completed) {
+    clearPendingOutgoing()
+    if (incoming) {
+      viewState = Model.viewAfterOutgoing(true, terminalState)
+      cursorRequested(1)
+      statusText = "Incoming transfer"
+      errorText = ""
+      progress = 0
+      return
+    }
+    if (incomingTextPending) { incomingTextPending=false; viewState="text"; statusText="Text received"; errorText=""; progress=0; return }
+    viewState = Model.viewAfterOutgoing(false, terminalState)
+    statusText = message
+    errorText = terminalState === "error" ? message : ""
+    if (completed) progress = 1
+  }
+  function finishText() { incomingText=""; incomingTextPending=false; viewState="nearby"; cursorRequested(0); startDiscovery() }
+  function finishTerminal() { viewState="nearby"; cursorRequested(0); startDiscovery() }
+  function handleBackendExit(code) {
+    backendReady=false; discoveryActive=false; incomingQueue=[]; incomingTextPending=false; activeIncomingSession=""; clearPendingOutgoing()
+    if (shutdownPending) { finishReceiverShutdown(); return }
+    if (!receiverEnabled) { statusText="Turned off"; errorText=""; return }
+    if (backendVersionMismatch) return
+    if (!backendAcceptedThisRun) {
+      errorText="Nearby backend could not start. Run the Nearby installer again or build it with ./build.sh."
+      statusText=errorText
+      return
+    }
+    errorText=code===0 ? "Receiver stopped" : "Receiver unavailable"
+    statusText=errorText
+    if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; errorText="Nearby backend stopped during transfer"; statusText=errorText }
+    if (backendRestart.attempts < 4) { backendRestart.attempts++; backendRestart.interval=Math.min(30000,1000*Math.pow(2,backendRestart.attempts-1)); backendRestart.restart() }
+  }
+  function handleEvent(event) {
+    if (!event || !event.event) return
+    if (backendVersionMismatch && event.event !== "ready") return
+    if (event.event === "ready") {
+      if (!Model.helperVersionMatches(pluginVersion, event.helperVersion)) {
+        backendReady=false
+        backendVersionMismatch=true
+        errorText="Nearby backend version mismatch. Run the Nearby installer again."
+        statusText=errorText
+        send({command:"shutdown"})
+        return
+      }
+      backendAcceptedThisRun=true; backendReady=true; backendVersionMismatch=false; backendRestart.attempts=0; statusText="Ready to receive"; errorText=""; if(anyViewOpen&&viewState==="nearby")startDiscovery()
+    }
+    else if (event.event === "peer_snapshot") { devices=Model.snapshotDevices(event.devices); statusText=devices.length ? "Ready" : "Looking nearby…" }
+    else if (event.event === "device") { devices=Model.upsertDevice(devices,event.device); statusText=devices.length ? "Ready" : "Looking nearby…" }
+    else if (event.event === "discovery_started") discoveryActive=true
+    else if (event.event === "discovery_stopped") discoveryActive=false
+    else if (event.event === "incoming_request") {
+      incomingQueue=Model.enqueueIncoming(incomingQueue,event); if(!incomingTextPending)incomingText=""; if (viewState!=="sending" && viewState!=="receiving" && viewState!=="pin") { viewState="incoming"; cursorRequested(1) }
+      Quickshell.execDetached(["notify-send","-a","Nearby","Incoming transfer",String(event.sender)+" wants to send "+Model.incomingSummary(event.files)])
+    }
+    else if (event.event === "incoming_text") {
+      incomingText=String(event.text || ""); transferPeer=String(event.sender || ""); incomingTextPending=pendingOutgoing!==null; if (!pendingOutgoing) { viewState="text"; stopDiscovery() }
+      Quickshell.execDetached(["notify-send","-a","Nearby","Text received","From "+String(event.sender || "")])
+    }
+    else if (event.event === "incoming_accepted") { incomingQueue=Model.removeIncoming(incomingQueue,event.requestId) }
+    else if (event.event === "incoming_expired") {
+      var expiredWasCurrent=incoming&&incoming.requestId===event.requestId
+      incomingQueue=Model.removeIncoming(incomingQueue,event.requestId)
+      if (expiredWasCurrent&&(viewState==="incoming"||(viewState==="receiving"&&activeIncomingSession===""))) {
+        if (incoming) { statusText="Incoming transfer"; cursorRequested(1) }
+        else if (incomingTextPending) { incomingTextPending=false; viewState="text"; statusText="Text received"; errorText="" }
+        else { viewState="error"; errorText="Transfer request expired"; statusText=errorText }
+      }
+    }
+    else if (event.event === "incoming_progress") { if(activeIncomingSession===""){if(viewState!=="receiving")return;activeIncomingSession=String(event.sessionId)} if(activeIncomingSession!==String(event.sessionId))return; if(pendingOutgoing)return; viewState="receiving"; transferName=String(event.name); transferPeer=String(event.sender); progress=event.total>0 ? event.bytes/event.total : 0 }
+    else if (event.event === "file_received") { if(activeIncomingSession===""){if(viewState!=="receiving")return;activeIncomingSession=String(event.sessionId)} if(activeIncomingSession!==String(event.sessionId))return; lastReceivedPath=String(event.path); if(pendingOutgoing)return; transferName=String(event.name); transferPeer=String(event.sender) }
+    else if (event.event === "incoming_done") { if(activeIncomingSession!==String(event.sessionId))return; finishIncoming("success","Received",true) }
+    else if (event.event === "incoming_cancelled") { if(activeIncomingSession===""){if(viewState!=="receiving")return;activeIncomingSession=String(event.sessionId)} if(activeIncomingSession!==String(event.sessionId))return; finishIncoming("error","Transfer cancelled",false) }
+    else if (event.event === "incoming_failed") { if(activeIncomingSession===""){if(viewState!=="receiving")return;activeIncomingSession=String(event.sessionId)} if(activeIncomingSession!==String(event.sessionId))return; finishIncoming("error",String(event.message||"Transfer failed"),false) }
+    else if (event.event === "incoming_declined") { incomingQueue=Model.removeIncoming(incomingQueue,event.requestId) }
+    else if (event.event === "outgoing_preparing") { if(String(event.transferId)!==outgoingTransferId)return; viewState="sending"; transferName=String(event.name); transferPeer=String(event.target); progress=0; stopDiscovery() }
+    else if (event.event === "outgoing_progress") { if(String(event.transferId)!==outgoingTransferId)return; viewState="sending"; progress=event.total>0 ? event.bytes/event.total : 0 }
+    else if (event.event === "outgoing_done") { if(String(event.transferId)!==outgoingTransferId)return; finishOutgoing("success", "Sent", true) }
+    else if (event.event === "outgoing_cancelled") { if(String(event.transferId)!==outgoingTransferId)return; finishOutgoing("error", "Transfer cancelled", false) }
+    else if (event.event === "outgoing_pin_required") { if(String(event.transferId)!==outgoingTransferId)return; showPinPrompt("") }
+    else if (event.event === "outgoing_invalid_pin") { if(String(event.transferId)!==outgoingTransferId)return; showPinPrompt("Incorrect PIN") }
+    else if (event.event === "outgoing_failed") { if(event.transferId && String(event.transferId)!==outgoingTransferId)return; finishOutgoing("error", String(event.message||"Transfer failed"), false) }
+    else if (event.event === "error") { viewState="error"; errorText=String(event.message||"Transfer failed"); statusText=errorText }
+  }
+
+  Process {
+    id: backend
+    command: [root.pluginDir + "/bin/omarchy-nearby-helper"]
+    running: root.receiverEnabled && root.pluginVersion !== ""
+    stdinEnabled: true
+    stdout: SplitParser { onRead: function(line) { root.handleEvent(Model.parseLine(line)) } }
+    stderr: SplitParser { onRead: function(line) { console.warn("nearby backend", line) } }
+    onStarted: {
+      root.backendAcceptedThisRun=false
+      root.backendVersionMismatch=false
+    }
+    onExited: function(code) { root.handleBackendExit(code) }
+  }
+  Timer { id: backendRestart; property int attempts: 0; interval: 1000; repeat: false; onTriggered: if (root.receiverEnabled && !backend.running) backend.running=true }
+  Timer { id: receiverShutdownFallback; interval: 250; repeat: false; onTriggered: root.finishReceiverShutdown() }
+}

--- a/Service.qml
+++ b/Service.qml
@@ -32,15 +32,25 @@ Item {
     ? metadataSourceDir
     : (Quickshell.env("HOME") || "") + "/.config/omarchy/plugins/" + manifestPluginId
 
-  // The bar entry a widget was configured from. Settings persist against this
-  // id, which the host may have replaced with an instance id.
-  property string moduleEntryId: manifestPluginId
-  property var pluginSettings: ({})
-  property bool receiverConfigured: false
+  // Settings come from shell.json, not from the widgets.
+  //
+  // A widget cannot be the source here. The bar builds one per monitor and
+  // injects `settings` a tick after the widget is created, so the first thing
+  // a widget can report is the default rather than the persisted value, and
+  // the rest are copies of the same entry. Reading the entry directly means
+  // the persisted state and the effective state are the same value, so they
+  // cannot drift apart, and `receiverConfigured` is a fact about the config
+  // rather than about which widget spoke first.
+  readonly property var configEntry: shell && shell.shellConfig
+    ? Model.barEntry(shell.shellConfig, manifestPluginId)
+    : null
+  readonly property bool receiverConfigured: configEntry !== null
+  readonly property string moduleEntryId: configEntry ? configEntry.id : manifestPluginId
+  readonly property var pluginSettings: configEntry ? configEntry.settings : ({})
+  readonly property bool receiverEnabled: Model.receiverEnabledIn(configEntry)
 
   property string pluginVersion: ""
   property bool backendReady: false
-  property bool receiverEnabled: true
   property bool discoveryActive: false
   property var devices: []
   property var selectedDevice: null
@@ -118,13 +128,6 @@ Item {
     function status(): string { return JSON.stringify({enabled:root.receiverEnabled,ready:root.backendReady,running:backend.running,devices:root.devices.length}) }
   }
 
-  function configure(entryId, settings) {
-    if (String(entryId || "") !== "") moduleEntryId = String(entryId)
-    pluginSettings = settings || {}
-    if (receiverConfigured) return
-    receiverConfigured = true
-    receiverEnabled = pluginSettings.receiverEnabled !== false
-  }
   function viewOpened() {
     openViewCount++
     if (openViewCount !== 1) return
@@ -139,10 +142,11 @@ Item {
     if (!backend.running) return
     backend.write(JSON.stringify(command) + "\n")
   }
+  // receiverEnabled follows the entry, so writing the entry is what turns the
+  // receiver on or off. There is no second copy of the state to keep in step.
   function persistReceiverEnabled(enabled) {
-    receiverEnabled = enabled
-    pluginSettings = Object.assign({}, pluginSettings, { receiverEnabled: enabled })
-    if (shell) shell.updateEntryInline(moduleEntryId, pluginSettings)
+    if (!shell) return
+    shell.updateEntryInline(moduleEntryId, Object.assign({}, pluginSettings, { receiverEnabled: enabled }))
   }
   function toggleReceiver() {
     if (shutdownPending) return
@@ -332,7 +336,10 @@ Item {
     id: backend
     property bool launched: false
     command: [root.pluginDir + "/bin/omarchy-nearby-helper"]
-    running: root.receiverEnabled && root.pluginVersion !== ""
+    // Not eligible to start until shell.json has been read. Defaulting to on
+    // before then would let the helper bind the LocalSend port and announce
+    // itself on the network for a user who had turned the receiver off.
+    running: root.receiverConfigured && root.receiverEnabled && root.pluginVersion !== ""
     stdinEnabled: true
     stdout: SplitParser { onRead: function(line) { root.handleEvent(Model.parseLine(line)) } }
     stderr: SplitParser { onRead: function(line) { console.warn("nearby backend", line) } }

--- a/Service.qml
+++ b/Service.qml
@@ -146,7 +146,15 @@ Item {
   // receiver on or off. There is no second copy of the state to keep in step.
   function persistReceiverEnabled(enabled) {
     if (!shell) return
-    shell.updateEntryInline(moduleEntryId, Object.assign({}, pluginSettings, { receiverEnabled: enabled }))
+    var settings = Object.assign({}, pluginSettings, { receiverEnabled: enabled })
+    if (Model.hasStringBarEntry(shell.shellConfig, moduleEntryId)
+        && typeof shell.mutateShellConfig === "function") {
+      shell.mutateShellConfig(function(config) {
+        Model.promoteStringBarEntry(config, moduleEntryId, settings)
+      })
+      return
+    }
+    shell.updateEntryInline(moduleEntryId, settings)
   }
   function toggleReceiver() {
     if (shutdownPending) return

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "omarchy-nearby-helper"
-version = "1.0.5"
+version = "1.0.6-dev"
 dependencies = [
  "anyhow",
  "localsend-rs",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omarchy-nearby-helper"
-version = "1.0.5"
+version = "1.0.6-dev"
 edition = "2024"
 license = "MIT"
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -25,6 +25,21 @@ const MULTICAST_GRACE: Duration = Duration::from_secs(1);
 const CACHED_PROBE_CONCURRENCY: usize = 5;
 const MAX_SUBNET_ADDRESSES: u32 = 1024;
 const STALE_PARTIAL_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const NEARBY_PORT: u16 = 53317;
+
+/// True when a failure was caused by the LocalSend port already being bound.
+///
+/// The bind failure surfaces as an `io::Error` several layers down, so the
+/// whole chain is searched rather than only the error we were handed. Callers
+/// use this to tell a port that is taken, which the user can act on, from a
+/// receiver that failed for any other reason.
+fn caused_by_port_in_use(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io| io.kind() == std::io::ErrorKind::AddrInUse)
+    })
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
@@ -744,16 +759,30 @@ async fn main() -> Result<()> {
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "Omarchy".into());
     let certificate = load_identity(&home).context("TLS identity unavailable")?;
-    let (server, mut events) = LocalSendServer::builder()
+    let started = LocalSendServer::builder()
         .alias(alias)
-        .port(53317)
+        .port(NEARBY_PORT)
         .save_dir(&canonical_download)
         .protocol(Protocol::Https)
         .tls_certificate(certificate.clone())
         .auto_accept(false)
         .build()
-        .await
-        .context("receiver could not start")?;
+        .await;
+    let (server, mut events) = match started {
+        Ok(started) => started,
+        Err(error) => {
+            let error = anyhow::Error::new(error);
+            // A taken port is the one startup failure with an obvious remedy,
+            // so it is worth saying out loud. Reinstalling the plugin, which a
+            // generic failure used to suggest, never frees it.
+            if caused_by_port_in_use(&error) {
+                return Err(error.context(format!(
+                    "receiver could not start: port {NEARBY_PORT} is already in use by another LocalSend receiver"
+                )));
+            }
+            return Err(error.context("receiver could not start"));
+        }
+    };
     let identity = server.device().clone();
     let registry = Arc::new(Mutex::new(HashMap::<String, Peer>::new()));
     let (peer_tx, mut peer_rx) = mpsc::unbounded_channel::<DeviceInfo>();
@@ -917,6 +946,24 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn port_in_use_is_recognized_through_the_error_chain() {
+        // The bind failure reaches us wrapped, the way LocalSendServer::build
+        // reports it, so detection has to search past the outermost error.
+        let bind = std::io::Error::new(std::io::ErrorKind::AddrInUse, "Address already in use");
+        let wrapped = anyhow::Error::new(bind).context("IO error");
+        assert!(caused_by_port_in_use(&wrapped));
+    }
+
+    #[test]
+    fn other_failures_are_not_reported_as_a_port_conflict() {
+        let denied = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let wrapped = anyhow::Error::new(denied).context("IO error");
+        assert!(!caused_by_port_in_use(&wrapped));
+        assert!(!caused_by_port_in_use(&anyhow!("TLS identity unavailable")));
+    }
+
     #[test]
     fn peer_registry_keeps_valid_and_expires_stale() {
         let d = DeviceInfo::new("Phone".into(), 53317, Protocol::Http);

--- a/manifest.json
+++ b/manifest.json
@@ -2,13 +2,15 @@
   "schemaVersion": 1,
   "id": "oma.nearby",
   "name": "Nearby",
-  "version": "1.0.5",
+  "version": "1.0.6-dev",
   "author": "jfg96",
   "description": "Native nearby sharing compatible with the LocalSend protocol",
   "kinds": [
+    "service",
     "bar-widget"
   ],
   "entryPoints": {
+    "service": "Service.qml",
     "barWidget": "Panel.qml"
   },
   "barWidget": {

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -35,4 +35,32 @@ assert.equal(Model.manifestVersion('{"id":"oma.nearby","version":"1.0.2"}', "oma
 assert.equal(Model.manifestVersion('{"id":"other.plugin","version":"1.0.2"}', "oma.nearby"), "")
 assert.equal(Model.manifestVersion('{"id":"oma.nearby"}', "oma.nearby"), "")
 assert.equal(Model.manifestVersion("not json", "oma.nearby"), "")
+// The service reads its own entry out of shell.json. An absent entry is a
+// config that has not been applied yet, which is why it is null rather than an
+// empty settings object: the receiver stays off until the entry is seen, so a
+// persisted off is never briefly treated as on.
+const layoutOff = {version:1, bar:{layout:{left:[{id:"omarchy.menu"}], center:[], right:[{id:"b.omadoro"},{id:"oma.nearby",receiverEnabled:false}]}}, plugins:[]}
+assert.deepEqual(Model.barEntry(layoutOff, "oma.nearby"), {id:"oma.nearby", settings:{receiverEnabled:false}})
+assert.equal(Model.receiverEnabledIn(Model.barEntry(layoutOff, "oma.nearby")), false)
+
+const layoutDefault = {version:1, bar:{layout:{right:[{id:"oma.nearby"}]}}, plugins:[]}
+assert.deepEqual(Model.barEntry(layoutDefault, "oma.nearby"), {id:"oma.nearby", settings:{}})
+assert.equal(Model.receiverEnabledIn(Model.barEntry(layoutDefault, "oma.nearby")), true,
+  "an entry with no receiver setting means on, the way it always has")
+
+assert.equal(Model.barEntry(layoutDefault, "other.plugin"), null)
+assert.equal(Model.barEntry({version:1, bar:{layout:{right:[]}}, plugins:[]}, "oma.nearby"), null)
+assert.equal(Model.barEntry(null, "oma.nearby"), null)
+assert.equal(Model.barEntry(undefined, "oma.nearby"), null)
+assert.equal(Model.barEntry({}, "oma.nearby"), null)
+assert.equal(Model.barEntry(layoutDefault, ""), null)
+assert.equal(Model.receiverEnabledIn(null), false,
+  "no entry means the receiver is not eligible to run yet, not that it defaults to on")
+
+// Non-widget plugin entries live in plugins[] instead of the bar layout.
+assert.deepEqual(Model.barEntry({version:1, plugins:[{id:"oma.nearby",receiverEnabled:false}]}, "oma.nearby"),
+  {id:"oma.nearby", settings:{receiverEnabled:false}})
+// Malformed entries must not throw or match.
+assert.equal(Model.barEntry({version:1, bar:{layout:{right:[null,"oma.nearby",42]}}}, "oma.nearby"), null)
+
 console.log("Model tests passed")

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -48,6 +48,33 @@ assert.deepEqual(Model.barEntry(layoutDefault, "oma.nearby"), {id:"oma.nearby", 
 assert.equal(Model.receiverEnabledIn(Model.barEntry(layoutDefault, "oma.nearby")), true,
   "an entry with no receiver setting means on, the way it always has")
 
+// Quattro accepts a widget id directly in a bar layout and normalizes it to an
+// object entry. Reading shell.json directly must preserve those same semantics.
+const layoutString = {version:1, bar:{layout:{right:["oma.nearby"]}}, plugins:[]}
+assert.deepEqual(Model.barEntry(layoutString, "oma.nearby"), {id:"oma.nearby", settings:{}},
+  "a matching string-form bar entry must be recognized as configured")
+assert.equal(Model.receiverEnabledIn(Model.barEntry(layoutString, "oma.nearby")), true,
+  "a string-form entry with no receiver setting must use the default-on behavior")
+for (const region of ["left", "center", "right"]) {
+  const config = {version:1, bar:{layout:{left:[], center:[], right:[]}}, plugins:[]}
+  config.bar.layout[region] = ["oma.nearby"]
+  assert.deepEqual(Model.barEntry(config, "oma.nearby"), {id:"oma.nearby", settings:{}},
+    `a string-form entry in bar.layout.${region} must be recognized`)
+}
+const promotedLayout = {
+  version:1,
+  bar:{layout:{left:[], center:[], right:["other.before", "oma.nearby", {id:"other.after", x:1}]}},
+  plugins:[],
+}
+assert.equal(Model.hasStringBarEntry(promotedLayout, "oma.nearby"), true)
+assert.equal(Model.promoteStringBarEntry(promotedLayout, "oma.nearby", {receiverEnabled:false}), true)
+assert.deepEqual(promotedLayout.bar.layout.right,
+  ["other.before", {id:"oma.nearby", receiverEnabled:false}, {id:"other.after", x:1}],
+  "promoting a string entry must preserve its region, slot, and neighboring entries")
+assert.equal(Model.hasStringBarEntry(promotedLayout, "oma.nearby"), false)
+assert.equal(Model.promoteStringBarEntry(promotedLayout, "oma.nearby", {receiverEnabled:true}), false,
+  "promotion must not append or duplicate an entry that is already object-form")
+
 assert.equal(Model.barEntry(layoutDefault, "other.plugin"), null)
 assert.equal(Model.barEntry({version:1, bar:{layout:{right:[]}}, plugins:[]}, "oma.nearby"), null)
 assert.equal(Model.barEntry(null, "oma.nearby"), null)
@@ -60,7 +87,9 @@ assert.equal(Model.receiverEnabledIn(null), false,
 // Non-widget plugin entries live in plugins[] instead of the bar layout.
 assert.deepEqual(Model.barEntry({version:1, plugins:[{id:"oma.nearby",receiverEnabled:false}]}, "oma.nearby"),
   {id:"oma.nearby", settings:{receiverEnabled:false}})
-// Malformed entries must not throw or match.
-assert.equal(Model.barEntry({version:1, bar:{layout:{right:[null,"oma.nearby",42]}}}, "oma.nearby"), null)
+// Malformed entries must not throw or match. String entries are valid only in
+// the bar layout; Quattro's top-level plugins[] lookup requires object entries.
+assert.equal(Model.barEntry({version:1, bar:{layout:{right:[null,"other.plugin",42]}}}, "oma.nearby"), null)
+assert.equal(Model.barEntry({version:1, plugins:["oma.nearby"]}, "oma.nearby"), null)
 
 console.log("Model tests passed")

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -86,7 +86,7 @@ function extractFunction(name) {
 }
 
 const functionNames = [
-  "pushSettings", "syncOpenState", "toggleReceiver", "startDiscovery", "forceFullDiscovery",
+  "syncOpenState", "toggleReceiver", "startDiscovery", "forceFullDiscovery",
   "chooseDevice", "acceptIncoming", "declineIncoming", "finishText", "finishTerminal",
   "cancelOutgoing", "cancelPin", "retryWithPin", "failWith", "noteTextCopied", "beginOutgoing",
   "goBack", "selectFiles", "sendClipboard", "copyReceivedText", "moveCursor", "activateCursor",
@@ -114,7 +114,6 @@ function stubEngine() {
     failWith: record("failWith"),
     noteTextCopied: record("noteTextCopied"),
     beginOutgoing: record("beginOutgoing"),
-    configure: record("configure"),
     viewOpened: record("viewOpened"),
     viewClosed: record("viewClosed"),
   }
@@ -262,10 +261,15 @@ function callNames(state) {
 }
 
 {
-  const state = panel({settings: {receiverEnabled: false}})
-  state.pushSettings()
-  assert.deepEqual(state.engine.calls.at(-1), ["configure", "oma.nearby", {receiverEnabled: false}],
-    "each view hands its entry settings to the engine, which owns what is persisted")
+  // The widget must not be the source of persisted settings. The bar injects
+  // `settings` a tick after the widget is built (Bar.qml: onActiveItemChanged
+  // -> Qt.callLater(injectProps)), so the first value a widget could report is
+  // the default, not the persisted one -- which is how a persisted
+  // receiverEnabled: false used to be replaced by the default on every start.
+  assert.equal(source.includes("configure("), false,
+    "the widget must not push settings into the engine; the engine reads shell.json")
+  assert.equal(/onSettingsChanged/.test(source), false,
+    "reacting to injected settings would reintroduce the widget as a config source")
 }
 
 {
@@ -277,7 +281,6 @@ function callNames(state) {
   state.retryWithPin()
   state.failWith("boom")
   state.noteTextCopied()
-  state.pushSettings()
   state.syncOpenState()
   assert.ok(true, "view actions without an engine must not throw")
 }

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -5,11 +5,39 @@ const Model = require("../Model.js")
 
 const source = fs.readFileSync(require.resolve("../Panel.qml"), "utf8")
 
+// The bar builds one widget per monitor (Variants over Quickshell.screens).
+// Anything there can only be one of belongs to the service, which the shell
+// loads once. When the widget owned the helper, the second monitor's copy lost
+// the race for the LocalSend port and reported a receiver that could not
+// start while the first copy was holding it.
+assert.equal(source.includes("omarchy-nearby-helper"), false,
+  "the widget must not spawn the helper: one would be started per monitor")
+assert.equal(source.includes("IpcHandler"), false,
+  "the widget must not register an IPC target: one handler would be registered per monitor")
+assert.match(source, /bar\.shell\.serviceFor\(manifestPluginId\)/,
+  "the widget must read its state from the single service instance")
+assert.match(source, /manageIpc:\s*false/,
+  "the base panel's IPC handler must stay off so the service owns the target")
+for (const owned of ["backendRestart", "receiverShutdownFallback", "handleEvent(", "handleBackendExit("]) {
+  assert.equal(source.includes(owned), false,
+    `${owned} is engine state and must not be duplicated per monitor`)
+}
+
+// Cursor position and popup focus are genuinely per monitor and stay here.
+assert.match(source, /onCursorRequested\(index\)\s*\{\s*root\.selectedIndex = index\s*\}/,
+  "the engine asks each view to move its own cursor rather than holding one")
+assert.match(source, /onOpenedChanged[\s\S]*?if \(root\.viewState==="pin"\) pinInput\.forceActiveFocus\(\)/,
+  "reopening a pending PIN prompt must restore focus to its input")
+assert.match(source, /Component\.onDestruction:\s*if \(engine && viewRegistered\) engine\.viewClosed\(\)/,
+  "a view torn down while open must release its claim on discovery")
+
 assert.equal(source.includes("closeStdin"), false, "Quickshell Process does not expose closeStdin")
 assert.match(source, /onStarted:\s*\{[^}]*write\(root\.incomingText\);\s*stdinEnabled=false\s*\}/,
   "clipboard writer must close stdin after writing so wl-copy can finish")
 assert.match(source, /onExited:\s*function\(code\)\s*\{\s*stdinEnabled=true;/,
   "clipboard writer must re-enable stdin for the next copy")
+assert.match(source, /onExited: function\(code\) \{ stdinEnabled=true; if\(root\.viewState!=="text"\)return;/,
+  "late wl-copy completion must not reopen a text result after the user exits")
 
 assert.equal(source.includes("zenity"), false,
   "files are chosen with omarchy-file-select, which Omarchy ships, rather than zenity")
@@ -21,6 +49,17 @@ for (const launcher of ["picker", "clipboard", "clipboardWriter"]) {
   assert.match(source, new RegExp(`onRunningChanged:\\s*if\\s*\\(!running && !${launcher}\\.launched`),
     `${launcher} must report a command that never launched, which Quickshell signals by ` +
     "returning running to false without an exit code")
+}
+
+for (const [failure, description] of [
+  ["Clipboard is empty", "clipboard read"],
+  ["wl-paste is required to read the clipboard", "missing wl-paste"],
+  ["wl-copy is required to copy received text", "clipboard write"],
+  ["The file chooser could not be started", "missing file chooser"],
+  ["The file chooser did not open", "file chooser fault"],
+]) {
+  assert.match(source, new RegExp(`failWith\\("${failure.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"\\)`),
+    `${description} errors must be raised through failWith`)
 }
 
 function extractFunction(name) {
@@ -47,357 +86,200 @@ function extractFunction(name) {
 }
 
 const functionNames = [
-  "send", "persistReceiverEnabled", "startDiscovery", "stopDiscovery", "clearPendingOutgoing", "dispatchPendingOutgoing",
-  "beginOutgoing", "retryWithPin", "showPinPrompt", "cancelPin",
-  "acceptIncoming", "declineIncoming", "finishIncoming", "finishOutgoing", "finishText", "finishTerminal", "finishReceiverShutdown", "activateCursor", "handleBackendExit", "handleEvent"
+  "pushSettings", "syncOpenState", "toggleReceiver", "startDiscovery", "forceFullDiscovery",
+  "chooseDevice", "acceptIncoming", "declineIncoming", "finishText", "finishTerminal",
+  "cancelOutgoing", "cancelPin", "retryWithPin", "failWith", "noteTextCopied", "beginOutgoing",
+  "goBack", "selectFiles", "sendClipboard", "copyReceivedText", "moveCursor", "activateCursor",
 ]
 
+// Every call the view makes has to land on the shared engine, so the stub
+// records rather than implements.
+function stubEngine() {
+  const calls = []
+  const record = name => (...args) => { calls.push([name, ...args]); return undefined }
+  return {
+    calls,
+    toggleReceiver: record("toggleReceiver"),
+    startDiscovery: record("startDiscovery"),
+    forceFullDiscovery: record("forceFullDiscovery"),
+    chooseDevice: record("chooseDevice"),
+    clearTarget: record("clearTarget"),
+    acceptIncoming: record("acceptIncoming"),
+    declineIncoming: record("declineIncoming"),
+    finishText: record("finishText"),
+    finishTerminal: record("finishTerminal"),
+    cancelOutgoing: record("cancelOutgoing"),
+    cancelPin: record("cancelPin"),
+    retryWithPin: record("retryWithPin"),
+    failWith: record("failWith"),
+    noteTextCopied: record("noteTextCopied"),
+    beginOutgoing: record("beginOutgoing"),
+    configure: record("configure"),
+    viewOpened: record("viewOpened"),
+    viewClosed: record("viewClosed"),
+  }
+}
+
 function panel(initial = {}) {
-  const sent = []
+  const closes = []
+  const engine = initial.engine === undefined ? stubEngine() : initial.engine
   const context = {
     Model,
-    Date: {now: () => 1000},
     Qt: {callLater: callback => callback()},
-    Quickshell: {execDetached: () => {}},
-    backend: {running: true, write: line => sent.push(JSON.parse(line))},
+    engine,
+    picker: {running: false, launched: false},
+    clipboard: {running: false, launched: false},
+    clipboardWriter: {running: false, launched: false},
     pinInput: {text: "", forceActiveFocus: () => {}},
     keyCatcher: {forceActiveFocus: () => {}},
-    clipboardWriter: {running: false},
-    backendRestart: {attempts: 0, interval: 0, restart: () => {}},
-    receiverShutdownFallback: {stop: () => {}},
-    settings: {},
-    bar: null,
+    close: () => closes.push(true),
     moduleName: "oma.nearby",
-    shutdownPending: false,
-    pluginVersion: "1.0.4",
-    backendVersionMismatch: false,
-    backendReady: true,
-    backendAcceptedThisRun: true,
+    settings: {},
     opened: true,
-    receiverEnabled: true,
-    discoveryActive: false,
+    viewRegistered: false,
+    selectedIndex: 0,
+    cursorActive: false,
     devices: [],
     selectedDevice: {fingerprint: "phone", alias: "Phone"},
     viewState: "target",
-    statusText: "",
-    errorText: "",
-    selectedIndex: 0,
-    cursorActive: false,
-    incomingQueue: [],
-    incomingText: "",
-    incomingTextPending: false,
-    lastReceivedPath: "",
-    progress: 0,
-    transferName: "",
-    transferPeer: "",
-    activeIncomingSession: "",
-    outgoingTransferId: "",
-    pendingOutgoing: null,
-    pinError: "",
-    transferSequence: 0,
     ...initial,
   }
-  Object.defineProperty(context, "incoming", {get() { return Model.currentIncoming(context.incomingQueue) }})
+  context.engine = engine
   vm.createContext(context)
   vm.runInContext(functionNames.map(extractFunction).join("\n"), context)
-  context.sent = sent
+  context.closes = closes
   return context
 }
 
-function incoming(requestId, sender = requestId) {
-  return {event: "incoming_request", requestId, sender, files: [{name: `${requestId}.txt`}], total: 1}
+function callNames(state) {
+  return state.engine.calls.map(call => call[0])
 }
 
 {
-  const state = panel()
-  state.handleEvent(incoming("a"))
-  state.handleEvent(incoming("b"))
-  state.declineIncoming()
-  assert.deepEqual(state.incomingQueue.map(item => item.requestId), ["b"])
-  assert.equal(state.incoming.requestId, "b")
-  assert.equal(state.viewState, "incoming")
-}
-
-{
-  const state = panel()
-  state.handleEvent(incoming("a"))
-  state.handleEvent(incoming("b"))
-  state.handleEvent({event: "incoming_expired", requestId: "a"})
-  assert.equal(state.incoming.requestId, "b")
-  assert.equal(state.viewState, "incoming")
-  state.handleEvent({event: "incoming_expired", requestId: "unknown"})
-  assert.equal(state.incoming.requestId, "b")
-}
-
-{
-  const state = panel()
-  state.handleEvent(incoming("a"))
-  state.acceptIncoming()
-  assert.equal(state.viewState, "receiving")
-  state.handleEvent({event: "incoming_expired", requestId: "a"})
-  assert.notEqual(state.viewState, "receiving",
-    "an expired approval must not leave the UI waiting for a receive session that cannot start")
-  assert.equal(state.activeIncomingSession, "")
-}
-
-{
-  const state = panel()
-  state.handleEvent(incoming("a"))
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "one"})
-  const transferId = state.outgoingTransferId
-  state.handleEvent({event: "outgoing_preparing", transferId, name: "message.txt", target: "Phone"})
-  state.handleEvent({event: "outgoing_done", transferId})
-  assert.equal(state.incoming.requestId, "a")
-  assert.equal(state.viewState, "incoming")
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "original"})
-  const firstId = state.outgoingTransferId
-  state.handleEvent({event: "outgoing_pin_required", transferId: firstId})
-  state.handleEvent(incoming("a"))
-  state.pinInput.text = "000000"
-  state.retryWithPin()
-  const retryId = state.outgoingTransferId
-  state.handleEvent({event: "outgoing_invalid_pin", transferId: retryId})
-  state.handleEvent(incoming("b"))
-  state.pinInput.text = "123456"
-  state.retryWithPin()
-  assert.equal(state.sent.at(-1).text, "original")
-  assert.equal(state.sent.at(-1).pin, "123456")
-  assert.deepEqual(state.incomingQueue.map(item => item.requestId), ["a", "b"])
-  state.handleEvent({event: "incoming_expired", requestId: "a"})
-  assert.equal(state.viewState, "pin")
-  assert.equal(state.pendingOutgoing.text, "original")
-  assert.equal(state.incoming.requestId, "b")
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "only once"})
-  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
-  state.pinInput.text = "123456"
-  state.retryWithPin()
-  state.pinInput.text = "123456"
-  state.retryWithPin()
-  assert.equal(state.sent.filter(command => command.pin === "123456").length, 1,
-    "a repeated submit while a PIN retry is active must not dispatch a duplicate")
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "cancel retry"})
-  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
-  state.pinInput.text = "123456"
-  state.retryWithPin()
-  const retryId = state.outgoingTransferId
-  state.cancelPin()
-  assert.deepEqual(state.sent.filter(command => command.command === "cancel_outgoing"),
-    [{command: "cancel_outgoing", transfer_id: retryId}],
-    "leaving PIN while its retry is in flight must cancel that helper transfer exactly once")
-  assert.equal(state.pendingOutgoing, null)
-  assert.equal(state.outgoingTransferId, "")
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "keep me"})
-  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
-  const pending = state.pendingOutgoing
-  assert.match(source, /onOpenedChanged[\s\S]*?else\s*\{\s*stopDiscovery\(\)\s*\}/,
-    "closing the popup must only stop discovery, leaving a PIN retry pending")
-  assert.match(source, /onOpenedChanged[\s\S]*?if \(viewState==="pin"\) pinInput\.forceActiveFocus\(\)/,
-    "reopening a pending PIN prompt must restore focus to its input")
-  assert.equal(state.pendingOutgoing, pending)
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "pending"})
-  const transferId = state.outgoingTransferId
-  state.handleEvent({event: "outgoing_pin_required", transferId})
-  state.handleEvent({event: "incoming_cancelled", sessionId: "unknown"})
-  state.handleEvent({event: "incoming_failed", sessionId: "unknown", message: "late"})
-  assert.equal(state.viewState, "pin")
-  assert.equal(state.pendingOutgoing.text, "pending")
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "outgoing"})
-  const transferId = state.outgoingTransferId
-  state.handleEvent({event: "outgoing_preparing", transferId, name: "message.txt", target: "Phone"})
-  state.handleEvent({event: "incoming_cancelled", sessionId: "unknown"})
-  assert.equal(state.viewState, "sending")
-  assert.equal(state.outgoingTransferId, transferId)
-  state.handleEvent({event: "outgoing_done", transferId: "old"})
-  assert.equal(state.outgoingTransferId, transferId)
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "outgoing"})
-  const transferId = state.outgoingTransferId
-  state.handleEvent({event: "outgoing_pin_required", transferId})
-  state.handleEvent({event: "incoming_text", sessionId: "incoming-text", sender: "Alice", text: "hello"})
-  assert.equal(state.viewState, "pin", "incoming text must not hide an unrelated PIN prompt")
-  assert.ok(state.pendingOutgoing)
-  state.handleEvent({event: "outgoing_done", transferId: "old"})
-  assert.equal(state.viewState, "pin")
-  state.pinInput.text = "123456"
-  state.retryWithPin()
-  const retryId = state.outgoingTransferId
-  state.handleEvent({event: "outgoing_done", transferId: retryId})
-  assert.equal(state.viewState, "text", "deferred incoming text must become accessible after outgoing completion")
-  assert.equal(state.incomingText, "hello")
-}
-
-{
-  const state = panel({viewState: "receiving"})
-  state.handleEvent({event: "incoming_cancelled", sessionId: "session-a"})
-  assert.equal(state.viewState, "error")
-  assert.equal(state.activeIncomingSession, "")
-  state.handleEvent({event: "incoming_done", sessionId: "session-a"})
-  assert.equal(state.viewState, "error", "late terminal events must not resurrect a completed session")
-}
-
-{
-  const state = panel({viewState: "receiving"})
-  state.handleEvent({event: "incoming_progress", sessionId: "a", name: "a.txt", sender: "Alice", bytes: 1, total: 2})
-  state.handleEvent({event: "incoming_cancelled", sessionId: "a"})
-  state.handleEvent({event: "incoming_progress", sessionId: "a", name: "a.txt", sender: "Alice", bytes: 2, total: 2})
-  assert.equal(state.activeIncomingSession, "", "late progress must not resurrect cancelled incoming A")
-  assert.equal(state.viewState, "error")
-}
-
-{
-  const state = panel({viewState: "receiving"})
-  state.handleEvent({event: "incoming_progress", sessionId: "b", name: "b.txt", sender: "Bob", bytes: 1, total: 2})
-  state.handleEvent({event: "incoming_progress", sessionId: "a", name: "a.txt", sender: "Alice", bytes: 2, total: 2})
-  assert.equal(state.activeIncomingSession, "b")
-  assert.equal(state.transferName, "b.txt")
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "outgoing"})
-  const transferId = state.outgoingTransferId
-  state.handleEvent({event: "incoming_text", sender: "Alice", text: "deferred"})
-  state.handleEvent(incoming("files"))
-  state.handleEvent({event: "outgoing_done", transferId})
-  assert.equal(state.viewState, "incoming")
-  state.declineIncoming()
-  assert.equal(state.viewState, "text", "deferred text must follow the last queued file request")
-  assert.equal(state.incomingText, "deferred")
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "first"})
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "duplicate"})
-  assert.equal(state.sent.filter(command => command.command === "send_text").length, 1,
-    "a second begin before helper confirmation must not replace the active outgoing")
-  assert.equal(state.pendingOutgoing.text, "first")
-}
-
-{
-  const state = panel({backend: {running: false, write: () => { throw new Error("must not write") }}})
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "offline"})
-  assert.equal(state.pendingOutgoing, null, "backend downtime must not create a pending outgoing phantom")
-  assert.equal(state.outgoingTransferId, "")
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "first"})
-  const first = state.sent.at(-1)
-  state.handleEvent({event: "outgoing_done", transferId: first.transfer_id})
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "second"})
-  const second = state.sent.at(-1)
-  assert.notEqual(first.transfer_id, second.transfer_id)
-  assert.equal(first.text, "first")
-  assert.equal(second.text, "second")
-}
-
-{
-  const state = panel()
-  state.handleEvent(incoming("a"))
-  state.handleEvent(incoming("b"))
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "pending"})
-  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
-  state.activeIncomingSession = "session-a"
-  state.finishReceiverShutdown()
-  assert.equal(state.incomingQueue.length, 0)
-  assert.equal(state.incoming, null)
-  assert.equal(state.activeIncomingSession, "")
-  assert.equal(state.pendingOutgoing, null)
-  assert.equal(state.outgoingTransferId, "")
-  assert.equal(state.viewState, "nearby")
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "pending"})
-  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
-  state.handleBackendExit(1)
-  assert.equal(state.pendingOutgoing, null)
-  assert.equal(state.outgoingTransferId, "")
-  assert.equal(state.viewState, "error")
-  assert.match(state.errorText, /stopped|unavailable/i)
-}
-
-{
-  const state = panel()
-  state.handleEvent(incoming("a"))
-  state.handleBackendExit(1)
-  assert.equal(state.incoming, null)
-  assert.equal(state.activeIncomingSession, "")
-  assert.equal(state.viewState, "error", "helper exit must not leave an empty incoming view")
-}
-
-{
-  const state = panel()
-  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "outgoing"})
-  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
-  state.handleEvent({event: "incoming_text", sender: "Alice", text: "keep this"})
-  state.cancelPin()
-  assert.equal(state.viewState, "text", "cancelling PIN must reveal already received deferred text")
-  assert.equal(state.incomingText, "keep this")
-  assert.equal(state.incomingTextPending, false)
-}
-
-{
-  const state = panel()
-  state.handleEvent({event: "incoming_text", sender: "Alice", text: "clipboard"})
-  assert.equal(state.viewState, "text")
-  state.selectedIndex = 1
+  const state = panel({viewState: "nearby", devices: [{alias: "A"}, {alias: "B"}], selectedIndex: 0})
   state.activateCursor()
-  assert.equal(state.viewState, "nearby", "received text must have an exit independent of wl-copy completion")
-  assert.match(source, /onExited: function\(code\) \{ stdinEnabled=true; if\(root\.viewState!=="text"\)return;/,
-    "late wl-copy completion must not reopen a text result after the user exits")
+  assert.deepEqual(state.engine.calls.at(-1), ["chooseDevice", 0])
+  state.selectedIndex = 2
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "forceFullDiscovery",
+    "the entry past the last device is the rescan action")
+  state.selectedIndex = -1
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "toggleReceiver",
+    "the cursor above the list is the receiver switch")
 }
 
 {
-  const keyboard = panel({viewState: "success", discoveryActive: false})
-  keyboard.activateCursor()
-  assert.equal(keyboard.viewState, "nearby")
-  assert.equal(keyboard.discoveryActive, true, "keyboard Done must restart discovery like the visual button")
-  assert.equal(keyboard.sent.at(-1).command, "discovery_start")
+  const state = panel({viewState: "incoming", selectedIndex: 1})
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "acceptIncoming")
+  state.selectedIndex = 0
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "declineIncoming")
 }
 
-assert.match(source,
-  /function failWith\(message\)\s*\{\s*viewState="error";\s*errorText=message;\s*statusText=errorText\s*\}/,
-  "failWith must keep statusText aligned with errorText for every failure that reaches it")
-for (const [failure, description] of [
-  ["Clipboard is empty", "clipboard read"],
-  ["wl-paste is required to read the clipboard", "missing wl-paste"],
-  ["wl-copy is required to copy received text", "clipboard write"],
-  ["The file chooser could not be started", "missing file chooser"],
-  ["The file chooser did not open", "file chooser fault"],
-]) {
-  assert.match(source, new RegExp(`failWith\\("${failure.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"\\)`),
-    `${description} errors must be raised through failWith`)
+{
+  const state = panel({viewState: "sending"})
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "cancelOutgoing")
+}
+
+{
+  const state = panel({viewState: "success"})
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "finishTerminal",
+    "keyboard Done must reach the engine the same way the visual button does")
+}
+
+{
+  const state = panel({viewState: "text", selectedIndex: 1})
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "finishText",
+    "received text must have an exit independent of wl-copy completion")
+}
+
+{
+  const state = panel({viewState: "nearby", devices: [{alias: "A"}, {alias: "B"}], selectedIndex: 0})
+  state.moveCursor(0, 1)
+  assert.equal(state.selectedIndex, 1)
+  state.moveCursor(0, 5)
+  assert.equal(state.selectedIndex, 2, "the cursor stops on the rescan entry past the last device")
+  state.moveCursor(0, -9)
+  assert.equal(state.selectedIndex, -1, "the cursor stops on the receiver switch above the list")
+  assert.equal(state.engine.calls.length, 0, "moving a cursor is local to one monitor")
+}
+
+{
+  const state = panel({viewState: "target"})
+  state.goBack()
+  assert.equal(callNames(state).at(-1), "clearTarget")
+  const pin = panel({viewState: "pin"})
+  pin.goBack()
+  assert.equal(callNames(pin).at(-1), "cancelPin")
+  const nearby = panel({viewState: "nearby"})
+  nearby.goBack()
+  assert.equal(nearby.closes.length, 1, "back from the root view closes this monitor's popup")
+  assert.equal(nearby.engine.calls.length, 0)
+}
+
+{
+  const state = panel()
+  state.pinInput.text = "123456"
+  state.retryWithPin()
+  assert.deepEqual(state.engine.calls.at(-1), ["retryWithPin", "123456"],
+    "the PIN is read from this monitor's field and handed to the shared engine")
+}
+
+{
+  const state = panel({selectedDevice: null})
+  state.selectFiles()
+  state.sendClipboard()
+  assert.equal(state.picker.running, false, "no chooser without a target device")
+  assert.equal(state.clipboard.running, false, "no clipboard read without a target device")
+  const ready = panel()
+  ready.selectFiles()
+  assert.equal(ready.picker.running, true)
+  ready.sendClipboard()
+  assert.equal(ready.clipboard.running, true)
+}
+
+{
+  const state = panel({picker: {running: true, launched: true}})
+  state.selectFiles()
+  assert.equal(state.picker.launched, true, "a chooser already open must not be relaunched")
+}
+
+{
+  // Discovery is engine state shared by every monitor, so a view registers and
+  // releases its claim exactly once.
+  const state = panel({opened: true, viewRegistered: false})
+  state.syncOpenState()
+  state.syncOpenState()
+  assert.deepEqual(callNames(state), ["viewOpened"], "an open view claims discovery once")
+  state.opened = false
+  state.syncOpenState()
+  assert.deepEqual(callNames(state), ["viewOpened", "viewClosed"])
+}
+
+{
+  const state = panel({settings: {receiverEnabled: false}})
+  state.pushSettings()
+  assert.deepEqual(state.engine.calls.at(-1), ["configure", "oma.nearby", {receiverEnabled: false}],
+    "each view hands its entry settings to the engine, which owns what is persisted")
+}
+
+{
+  // A widget can outlive its engine across a plugin reload; it must degrade
+  // rather than throw into the shell.
+  const state = panel({engine: null, viewState: "target"})
+  state.toggleReceiver()
+  state.goBack()
+  state.retryWithPin()
+  state.failWith("boom")
+  state.noteTextCopied()
+  state.pushSettings()
+  state.syncOpenState()
+  assert.ok(true, "view actions without an engine must not throw")
 }
 
 console.log("panel state tests passed")

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -1,0 +1,442 @@
+const assert = require("node:assert/strict")
+const fs = require("node:fs")
+const vm = require("node:vm")
+const Model = require("../Model.js")
+
+const source = fs.readFileSync(require.resolve("../Service.qml"), "utf8")
+const manifest = JSON.parse(fs.readFileSync(require.resolve("../manifest.json"), "utf8"))
+
+// The bar builds one widget per monitor, so anything that may exist only once
+// has to live behind the `service` kind, which the shell loads a single time.
+// A helper owned by the widget was started once per screen and every instance
+// after the first lost the race for the LocalSend port.
+assert.ok(manifest.kinds.includes("service"),
+  "the helper is a singleton, so the plugin must declare a service kind")
+assert.equal(manifest.entryPoints.service, "Service.qml",
+  "the service kind needs an entry point for the shell to load it")
+assert.match(source, /command:\s*\[root\.pluginDir \+ "\/bin\/omarchy-nearby-helper"\]/,
+  "the helper must be spawned from the service, not from a per-monitor widget")
+assert.match(source, /IpcHandler\s*\{\s*target:\s*"oma\.nearby"/,
+  "the IPC target must be registered once, from the service")
+
+// Opening a popup is per monitor even though the state behind it is not, so
+// those calls are handed back to the shell to route to the focused screen.
+for (const method of ["summon", "hide", "toggle"]) {
+  assert.match(source, new RegExp(`summonView\\("${method}"\\)`),
+    `${method} must route through the shell rather than a fixed widget instance`)
+}
+
+function extractFunction(name) {
+  const marker = `function ${name}`
+  const start = source.indexOf(marker)
+  assert.notEqual(start, -1, `Service.qml must define ${name}`)
+  const brace = source.indexOf("{", start)
+  let depth = 0
+  let quote = ""
+  let escaped = false
+  for (let index = brace; index < source.length; index++) {
+    const character = source[index]
+    if (quote) {
+      if (escaped) escaped = false
+      else if (character === "\\") escaped = true
+      else if (character === quote) quote = ""
+      continue
+    }
+    if (character === '"' || character === "'") quote = character
+    else if (character === "{") depth++
+    else if (character === "}" && --depth === 0) return source.slice(start, index + 1)
+  }
+  throw new Error(`Unterminated ${name}`)
+}
+
+const functionNames = [
+  "configure", "viewOpened", "viewClosed",
+  "send", "persistReceiverEnabled", "toggleReceiver", "finishReceiverShutdown",
+  "startDiscovery", "forceFullDiscovery", "stopDiscovery", "chooseDevice", "clearTarget",
+  "failWith", "cancelOutgoing", "noteTextCopied",
+  "clearPendingOutgoing", "dispatchPendingOutgoing", "beginOutgoing", "retryWithPin",
+  "showPinPrompt", "cancelPin", "acceptIncoming", "declineIncoming",
+  "finishIncoming", "finishOutgoing", "finishText", "finishTerminal",
+  "handleBackendExit", "handleEvent",
+]
+
+function engine(initial = {}) {
+  const sent = []
+  const cursors = []
+  const signals = {pinCleared: 0, pinFocusRequested: 0, focusRestoreRequested: 0}
+  const context = {
+    Model,
+    Date: {now: () => 1000},
+    Quickshell: {execDetached: () => {}},
+    backend: {running: true, write: line => sent.push(JSON.parse(line))},
+    backendRestart: {attempts: 0, interval: 0, restart: () => {}, stop: () => {}},
+    receiverShutdownFallback: {stop: () => {}, restart: () => {}},
+    // Views own their cursor and PIN field, so the engine only signals at them.
+    cursorRequested: index => cursors.push(index),
+    pinCleared: () => { signals.pinCleared++ },
+    pinFocusRequested: () => { signals.pinFocusRequested++ },
+    focusRestoreRequested: () => { signals.focusRestoreRequested++ },
+    shell: null,
+    moduleEntryId: "oma.nearby",
+    pluginSettings: {},
+    receiverConfigured: true,
+    openViewCount: 1,
+    anyViewOpen: true,
+    shutdownPending: false,
+    pluginVersion: "1.0.4",
+    backendVersionMismatch: false,
+    backendReady: true,
+    backendAcceptedThisRun: true,
+    receiverEnabled: true,
+    discoveryActive: false,
+    devices: [],
+    selectedDevice: {fingerprint: "phone", alias: "Phone"},
+    viewState: "target",
+    statusText: "",
+    errorText: "",
+    incomingQueue: [],
+    incomingText: "",
+    incomingTextPending: false,
+    lastReceivedPath: "",
+    progress: 0,
+    transferName: "",
+    transferPeer: "",
+    activeIncomingSession: "",
+    outgoingTransferId: "",
+    pendingOutgoing: null,
+    pinError: "",
+    transferSequence: 0,
+    ...initial,
+  }
+  Object.defineProperty(context, "incoming", {get() { return Model.currentIncoming(context.incomingQueue) }})
+  vm.createContext(context)
+  vm.runInContext(functionNames.map(extractFunction).join("\n"), context)
+  context.sent = sent
+  context.cursors = cursors
+  context.signals = signals
+  return context
+}
+
+function incoming(requestId, sender = requestId) {
+  return {event: "incoming_request", requestId, sender, files: [{name: `${requestId}.txt`}], total: 1}
+}
+
+{
+  const state = engine()
+  state.handleEvent(incoming("a"))
+  state.handleEvent(incoming("b"))
+  state.declineIncoming()
+  assert.deepEqual(state.incomingQueue.map(item => item.requestId), ["b"])
+  assert.equal(state.incoming.requestId, "b")
+  assert.equal(state.viewState, "incoming")
+}
+
+{
+  const state = engine()
+  state.handleEvent(incoming("a"))
+  state.handleEvent(incoming("b"))
+  state.handleEvent({event: "incoming_expired", requestId: "a"})
+  assert.equal(state.incoming.requestId, "b")
+  assert.equal(state.viewState, "incoming")
+  state.handleEvent({event: "incoming_expired", requestId: "unknown"})
+  assert.equal(state.incoming.requestId, "b")
+}
+
+{
+  const state = engine()
+  state.handleEvent(incoming("a"))
+  state.acceptIncoming()
+  assert.equal(state.viewState, "receiving")
+  state.handleEvent({event: "incoming_expired", requestId: "a"})
+  assert.notEqual(state.viewState, "receiving",
+    "an expired approval must not leave the UI waiting for a receive session that cannot start")
+  assert.equal(state.activeIncomingSession, "")
+}
+
+{
+  const state = engine()
+  state.handleEvent(incoming("a"))
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "one"})
+  const transferId = state.outgoingTransferId
+  state.handleEvent({event: "outgoing_preparing", transferId, name: "message.txt", target: "Phone"})
+  state.handleEvent({event: "outgoing_done", transferId})
+  assert.equal(state.incoming.requestId, "a")
+  assert.equal(state.viewState, "incoming")
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "original"})
+  const firstId = state.outgoingTransferId
+  state.handleEvent({event: "outgoing_pin_required", transferId: firstId})
+  state.handleEvent(incoming("a"))
+  state.retryWithPin("000000")
+  const retryId = state.outgoingTransferId
+  state.handleEvent({event: "outgoing_invalid_pin", transferId: retryId})
+  state.handleEvent(incoming("b"))
+  state.retryWithPin("123456")
+  assert.equal(state.sent.at(-1).text, "original")
+  assert.equal(state.sent.at(-1).pin, "123456")
+  assert.deepEqual(state.incomingQueue.map(item => item.requestId), ["a", "b"])
+  state.handleEvent({event: "incoming_expired", requestId: "a"})
+  assert.equal(state.viewState, "pin")
+  assert.equal(state.pendingOutgoing.text, "original")
+  assert.equal(state.incoming.requestId, "b")
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "only once"})
+  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
+  state.retryWithPin("123456")
+  state.retryWithPin("123456")
+  assert.equal(state.sent.filter(command => command.pin === "123456").length, 1,
+    "a repeated submit while a PIN retry is active must not dispatch a duplicate")
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "no pin"})
+  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
+  const before = state.sent.length
+  state.retryWithPin("")
+  assert.equal(state.sent.length, before, "an empty PIN must not dispatch a transfer")
+  assert.equal(state.pinError, "Enter the receiver PIN")
+  assert.ok(state.signals.pinFocusRequested > 0,
+    "an empty PIN must ask the open view to focus its own input")
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "cancel retry"})
+  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
+  state.retryWithPin("123456")
+  const retryId = state.outgoingTransferId
+  state.cancelPin()
+  assert.deepEqual(state.sent.filter(command => command.command === "cancel_outgoing"),
+    [{command: "cancel_outgoing", transfer_id: retryId}],
+    "leaving PIN while its retry is in flight must cancel that helper transfer exactly once")
+  assert.equal(state.pendingOutgoing, null)
+  assert.equal(state.outgoingTransferId, "")
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "keep me"})
+  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
+  const pending = state.pendingOutgoing
+  state.viewClosed()
+  assert.equal(state.discoveryActive, false, "the last view closing must stop discovery")
+  assert.equal(state.pendingOutgoing, pending, "closing a popup must leave a PIN retry pending")
+  assert.equal(state.viewState, "pin")
+}
+
+{
+  // Discovery follows the popup, and there is one popup per monitor, so it may
+  // only stop once the last of them has closed.
+  const state = engine({openViewCount: 0, viewState: "nearby", discoveryActive: false})
+  state.viewOpened()
+  state.viewOpened()
+  assert.equal(state.discoveryActive, true)
+  state.viewClosed()
+  assert.equal(state.discoveryActive, true,
+    "one monitor closing must not stop discovery while another popup is open")
+  state.viewClosed()
+  assert.equal(state.discoveryActive, false)
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "pending"})
+  const transferId = state.outgoingTransferId
+  state.handleEvent({event: "outgoing_pin_required", transferId})
+  state.handleEvent({event: "incoming_cancelled", sessionId: "unknown"})
+  state.handleEvent({event: "incoming_failed", sessionId: "unknown", message: "late"})
+  assert.equal(state.viewState, "pin")
+  assert.equal(state.pendingOutgoing.text, "pending")
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "outgoing"})
+  const transferId = state.outgoingTransferId
+  state.handleEvent({event: "outgoing_preparing", transferId, name: "message.txt", target: "Phone"})
+  state.handleEvent({event: "incoming_cancelled", sessionId: "unknown"})
+  assert.equal(state.viewState, "sending")
+  assert.equal(state.outgoingTransferId, transferId)
+  state.handleEvent({event: "outgoing_done", transferId: "old"})
+  assert.equal(state.outgoingTransferId, transferId)
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "outgoing"})
+  const transferId = state.outgoingTransferId
+  state.handleEvent({event: "outgoing_pin_required", transferId})
+  state.handleEvent({event: "incoming_text", sessionId: "incoming-text", sender: "Alice", text: "hello"})
+  assert.equal(state.viewState, "pin", "incoming text must not hide an unrelated PIN prompt")
+  assert.ok(state.pendingOutgoing)
+  state.handleEvent({event: "outgoing_done", transferId: "old"})
+  assert.equal(state.viewState, "pin")
+  state.retryWithPin("123456")
+  const retryId = state.outgoingTransferId
+  state.handleEvent({event: "outgoing_done", transferId: retryId})
+  assert.equal(state.viewState, "text", "deferred incoming text must become accessible after outgoing completion")
+  assert.equal(state.incomingText, "hello")
+}
+
+{
+  const state = engine({viewState: "receiving"})
+  state.handleEvent({event: "incoming_cancelled", sessionId: "session-a"})
+  assert.equal(state.viewState, "error")
+  assert.equal(state.activeIncomingSession, "")
+  state.handleEvent({event: "incoming_done", sessionId: "session-a"})
+  assert.equal(state.viewState, "error", "late terminal events must not resurrect a completed session")
+}
+
+{
+  const state = engine({viewState: "receiving"})
+  state.handleEvent({event: "incoming_progress", sessionId: "a", name: "a.txt", sender: "Alice", bytes: 1, total: 2})
+  state.handleEvent({event: "incoming_cancelled", sessionId: "a"})
+  state.handleEvent({event: "incoming_progress", sessionId: "a", name: "a.txt", sender: "Alice", bytes: 2, total: 2})
+  assert.equal(state.activeIncomingSession, "", "late progress must not resurrect cancelled incoming A")
+  assert.equal(state.viewState, "error")
+}
+
+{
+  const state = engine({viewState: "receiving"})
+  state.handleEvent({event: "incoming_progress", sessionId: "b", name: "b.txt", sender: "Bob", bytes: 1, total: 2})
+  state.handleEvent({event: "incoming_progress", sessionId: "a", name: "a.txt", sender: "Alice", bytes: 2, total: 2})
+  assert.equal(state.activeIncomingSession, "b")
+  assert.equal(state.transferName, "b.txt")
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "outgoing"})
+  const transferId = state.outgoingTransferId
+  state.handleEvent({event: "incoming_text", sender: "Alice", text: "deferred"})
+  state.handleEvent(incoming("files"))
+  state.handleEvent({event: "outgoing_done", transferId})
+  assert.equal(state.viewState, "incoming")
+  state.declineIncoming()
+  assert.equal(state.viewState, "text", "deferred text must follow the last queued file request")
+  assert.equal(state.incomingText, "deferred")
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "first"})
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "duplicate"})
+  assert.equal(state.sent.filter(command => command.command === "send_text").length, 1,
+    "a second begin before helper confirmation must not replace the active outgoing")
+  assert.equal(state.pendingOutgoing.text, "first")
+}
+
+{
+  const state = engine({backend: {running: false, write: () => { throw new Error("must not write") }}})
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "offline"})
+  assert.equal(state.pendingOutgoing, null, "backend downtime must not create a pending outgoing phantom")
+  assert.equal(state.outgoingTransferId, "")
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "first"})
+  const first = state.sent.at(-1)
+  state.handleEvent({event: "outgoing_done", transferId: first.transfer_id})
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "second"})
+  const second = state.sent.at(-1)
+  assert.notEqual(first.transfer_id, second.transfer_id)
+  assert.equal(first.text, "first")
+  assert.equal(second.text, "second")
+}
+
+{
+  const state = engine()
+  state.handleEvent(incoming("a"))
+  state.handleEvent(incoming("b"))
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "pending"})
+  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
+  state.activeIncomingSession = "session-a"
+  state.finishReceiverShutdown()
+  assert.equal(state.incomingQueue.length, 0)
+  assert.equal(state.incoming, null)
+  assert.equal(state.activeIncomingSession, "")
+  assert.equal(state.pendingOutgoing, null)
+  assert.equal(state.outgoingTransferId, "")
+  assert.equal(state.viewState, "nearby")
+}
+
+{
+  const state = engine()
+  state.beginOutgoing({kind: "text", device: state.selectedDevice, text: "pending"})
+  state.handleEvent({event: "outgoing_pin_required", transferId: state.outgoingTransferId})
+  state.handleBackendExit(1)
+  assert.equal(state.pendingOutgoing, null)
+  assert.equal(state.outgoingTransferId, "")
+  assert.equal(state.viewState, "error")
+  assert.match(state.errorText, /stopped|unavailable/i)
+}
+
+{
+  const state = engine()
+  state.handleEvent(incoming("a"))
+  state.handleBackendExit(1)
+  assert.equal(state.incoming, null)
+  assert.equal(state.activeIncomingSession, "")
+  assert.equal(state.viewState, "error", "helper exit must not leave an empty incoming view")
+}
+
+{
+  const state = engine()
+  state.handleEvent({event: "incoming_text", sender: "Alice", text: "clipboard"})
+  assert.equal(state.viewState, "text")
+  state.finishText()
+  assert.equal(state.viewState, "nearby", "received text must have an exit independent of wl-copy completion")
+  assert.equal(state.incomingText, "")
+}
+
+{
+  const state = engine({viewState: "text", incomingText: "copied"})
+  state.noteTextCopied()
+  assert.equal(state.viewState, "success")
+  assert.equal(state.statusText, "Received")
+  const late = engine({viewState: "nearby"})
+  late.noteTextCopied()
+  assert.equal(late.viewState, "nearby",
+    "late wl-copy completion must not reopen a text result after the user exits")
+}
+
+{
+  const state = engine({viewState: "success", discoveryActive: false})
+  state.finishTerminal()
+  assert.equal(state.viewState, "nearby")
+  assert.equal(state.discoveryActive, true, "Done must restart discovery")
+  assert.equal(state.sent.at(-1).command, "discovery_start")
+}
+
+{
+  const state = engine({receiverConfigured: false, receiverEnabled: true})
+  state.configure("oma.nearby", {receiverEnabled: false})
+  assert.equal(state.receiverEnabled, false, "a persisted off switch must survive a restart")
+  state.configure("oma.nearby", {receiverEnabled: false})
+  assert.equal(state.moduleEntryId, "oma.nearby")
+}
+
+{
+  // Every monitor's widget pushes the same settings, so configure has to be
+  // idempotent rather than clobbering a live receiver state.
+  const state = engine({receiverConfigured: false, receiverEnabled: true})
+  state.configure("oma.nearby", {receiverEnabled: true})
+  state.receiverEnabled = false
+  state.configure("oma.nearby", {receiverEnabled: true})
+  assert.equal(state.receiverEnabled, false,
+    "a second view configuring the engine must not revive a receiver the user turned off")
+}
+
+assert.match(source,
+  /function failWith\(message\)\s*\{\s*viewState="error";\s*errorText=message;\s*statusText=errorText\s*\}/,
+  "failWith must keep statusText aligned with errorText for every failure that reaches it")
+
+console.log("service state tests passed")

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -26,6 +26,14 @@ for (const method of ["summon", "hide", "toggle"]) {
     `${method} must route through the shell rather than a fixed widget instance`)
 }
 
+// A helper that is missing never reaches onExited: Quickshell drops `running`
+// without an exit code, the same way the file chooser reports a missing
+// command. That is the failure reinstalling actually fixes.
+assert.match(source, /onRunningChanged:\s*\{[\s\S]*?if \(backend\.launched\) return/,
+  "a helper that never launched must be reported from onRunningChanged")
+assert.match(source, /Run the Nearby installer again or build it with \.\/build\.sh\./,
+  "the reinstall hint belongs to the missing-helper case")
+
 function extractFunction(name) {
   const marker = `function ${name}`
   const start = source.indexOf(marker)
@@ -386,6 +394,33 @@ function incoming(requestId, sender = requestId) {
   assert.equal(state.incoming, null)
   assert.equal(state.activeIncomingSession, "")
   assert.equal(state.viewState, "error", "helper exit must not leave an empty incoming view")
+}
+
+{
+  // A helper that exits before announcing itself is the port-conflict case.
+  // It used to report a permanent failure and skip the retry schedule, so a
+  // port that freed up was never picked back up.
+  const restarts = []
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 0, interval: 0, restart() { restarts.push(this.attempts) }, stop: () => {}},
+  })
+  state.handleBackendExit(1)
+  assert.equal(state.backendRestart.attempts, 1,
+    "a helper that never became ready must still be retried")
+  assert.deepEqual(restarts, [1])
+  assert.doesNotMatch(state.errorText, /installer|build\.sh/,
+    "a helper that ran and exited is not fixed by reinstalling the plugin")
+}
+
+{
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 4, interval: 0, restart: () => { throw new Error("must not retry") }, stop: () => {}},
+  })
+  state.handleBackendExit(1)
+  assert.match(state.errorText, /53317/,
+    "a port conflict that outlasts the retry schedule must name the port it lost")
 }
 
 {

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -531,6 +531,55 @@ function incoming(requestId, sender = requestId) {
     "persisting the receiver must not drop unrelated inline settings")
 }
 
+{
+  // Quattro accepts string-form entries in bar.layout, but its existing
+  // updateEntryInline() only matches objects through entry.id. Persisting from
+  // a string must therefore promote that exact slot to object form rather than
+  // silently leaving the authoritative receiver state on.
+  const config = {
+    version: 1,
+    bar: {layout: {right: ["other.before", "oma.nearby", {id: "other.after", x: 1}]}},
+    plugins: [],
+  }
+  const shell = {
+    shellConfig: config,
+    updateEntryInline(id, settings) {
+      const entries = this.shellConfig.bar.layout.right
+      const index = entries.findIndex(entry => entry && entry.id === id)
+      if (index < 0) return false
+      entries[index] = {id, ...settings}
+      return true
+    },
+    mutateShellConfig(mutator) {
+      const copy = JSON.parse(JSON.stringify(this.shellConfig))
+      mutator(copy)
+      this.shellConfig = copy
+    },
+  }
+  const state = engine({
+    shell,
+    moduleEntryId: "oma.nearby",
+    pluginSettings: {},
+  })
+
+  state.persistReceiverEnabled(false)
+  assert.deepEqual(shell.shellConfig.bar.layout.right,
+    ["other.before", {id: "oma.nearby", receiverEnabled: false}, {id: "other.after", x: 1}],
+    "persisting off must promote the matching string in place without changing its neighbors")
+  const offEntry = Model.barEntry(shell.shellConfig, "oma.nearby")
+  assert.equal(Model.receiverEnabledIn(offEntry), false)
+  assert.equal(backendEligible({receiverConfigured: true, receiverEnabled: false, pluginVersion: "1.0.6-dev"}), false)
+
+  state.pluginSettings = offEntry.settings
+  state.persistReceiverEnabled(true)
+  const onEntry = Model.barEntry(shell.shellConfig, "oma.nearby")
+  assert.equal(Model.receiverEnabledIn(onEntry), true)
+  assert.equal(backendEligible({receiverConfigured: true, receiverEnabled: true, pluginVersion: "1.0.6-dev"}), true)
+  assert.equal(shell.shellConfig.bar.layout.right.filter(entry =>
+    entry === "oma.nearby" || (entry && entry.id === "oma.nearby")).length, 1,
+    "promoting and toggling a string-form entry must not create a duplicate")
+}
+
 assert.match(source,
   /function failWith\(message\)\s*\{\s*viewState="error";\s*errorText=message;\s*statusText=errorText\s*\}/,
   "failWith must keep statusText aligned with errorText for every failure that reaches it")

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -57,8 +57,21 @@ function extractFunction(name) {
   throw new Error(`Unterminated ${name}`)
 }
 
+// The eligibility rule is a binding, not a function, so it is pulled out of
+// the source and evaluated directly. That is what covers the startup window:
+// checking state after the fact would pass even if the helper had already
+// bound the port.
+function backendEligible(state) {
+  const match = source.match(/id: backend[\s\S]*?\n\s*running:\s*([^\n]+)/)
+  assert.notEqual(match, null, "Service.qml must bind the helper's running state")
+  const expression = match[1].trim()
+  assert.match(expression, /receiverConfigured/,
+    "eligibility must depend on having read the config, not only on the receiver switch")
+  return vm.runInNewContext(`(${expression})`, {root: state})
+}
+
 const functionNames = [
-  "configure", "viewOpened", "viewClosed",
+  "viewOpened", "viewClosed",
   "send", "persistReceiverEnabled", "toggleReceiver", "finishReceiverShutdown",
   "startDiscovery", "forceFullDiscovery", "stopDiscovery", "chooseDevice", "clearTarget",
   "failWith", "cancelOutgoing", "noteTextCopied",
@@ -452,22 +465,70 @@ function incoming(requestId, sender = requestId) {
 }
 
 {
-  const state = engine({receiverConfigured: false, receiverEnabled: true})
-  state.configure("oma.nearby", {receiverEnabled: false})
-  assert.equal(state.receiverEnabled, false, "a persisted off switch must survive a restart")
-  state.configure("oma.nearby", {receiverEnabled: false})
-  assert.equal(state.moduleEntryId, "oma.nearby")
+  // The startup window itself: the service exists before shell.json has been
+  // applied, so eligibility to run has to be false then, not merely corrected
+  // afterwards. Evaluating the binding is the only way to cover the window --
+  // checking receiverEnabled after the fact would pass even if the helper had
+  // already bound the port.
+  assert.equal(backendEligible({receiverConfigured: false, receiverEnabled: true, pluginVersion: "1.0.6-dev"}), false,
+    "the helper must not be eligible to start before shell.json has been read")
+  assert.equal(backendEligible({receiverConfigured: true, receiverEnabled: false, pluginVersion: "1.0.6-dev"}), false,
+    "a persisted receiverEnabled: false must keep the helper stopped")
+  assert.equal(backendEligible({receiverConfigured: true, receiverEnabled: true, pluginVersion: ""}), false,
+    "the helper must not start before its version is known")
+  assert.equal(backendEligible({receiverConfigured: true, receiverEnabled: true, pluginVersion: "1.0.6-dev"}), true)
 }
 
 {
-  // Every monitor's widget pushes the same settings, so configure has to be
-  // idempotent rather than clobbering a live receiver state.
-  const state = engine({receiverConfigured: false, receiverEnabled: true})
-  state.configure("oma.nearby", {receiverEnabled: true})
-  state.receiverEnabled = false
-  state.configure("oma.nearby", {receiverEnabled: true})
-  assert.equal(state.receiverEnabled, false,
-    "a second view configuring the engine must not revive a receiver the user turned off")
+  // Replaying the real startup order: the config arrives after the service is
+  // built, and a persisted off must never pass through an eligible state.
+  const off = {version: 1, bar: {layout: {right: [{id: "oma.nearby", receiverEnabled: false}]}}, plugins: []}
+  const observed = []
+  for (const config of [null, {version: 1, bar: {layout: {right: []}}, plugins: []}, off]) {
+    const entry = Model.barEntry(config, "oma.nearby")
+    observed.push(backendEligible({
+      receiverConfigured: entry !== null,
+      receiverEnabled: Model.receiverEnabledIn(entry),
+      pluginVersion: "1.0.6-dev",
+    }))
+  }
+  assert.deepEqual(observed, [false, false, false],
+    "a persisted off receiver must not become eligible at any point during startup")
+}
+
+{
+  // The persisted value and the effective value are one value, so they cannot
+  // diverge: there is nothing to synchronize and no snapshot to go stale.
+  const config = {version: 1, bar: {layout: {right: [{id: "oma.nearby", receiverEnabled: false}]}}, plugins: []}
+  const state = engine({shell: {shellConfig: config, updateEntryInline: () => true}})
+  const entry = Model.barEntry(config, "oma.nearby")
+  assert.equal(Model.receiverEnabledIn(entry), false)
+  assert.deepEqual(entry.settings, {receiverEnabled: false})
+  assert.equal(entry.id, "oma.nearby")
+  // Turning the receiver on writes the entry rather than a second copy of the
+  // state, so a later read of the config is what makes it effective.
+  const writes = []
+  // Objects built inside the vm realm carry that realm's prototype, so they
+  // are compared by value.
+  state.shell = {shellConfig: config, updateEntryInline: (id, settings) => { writes.push([id, JSON.parse(JSON.stringify(settings))]); return true }}
+  state.persistReceiverEnabled(true)
+  assert.deepEqual(writes, [["oma.nearby", {receiverEnabled: true}]],
+    "toggling must persist the entry, which is the only place the state lives")
+}
+
+{
+  // Other keys on the entry survive a receiver toggle.
+  const config = {version: 1, bar: {layout: {right: [{id: "oma.nearby", tooltip: "keep me"}]}}, plugins: []}
+  const entry = Model.barEntry(config, "oma.nearby")
+  const writes = []
+  const state = engine({
+    pluginSettings: entry.settings,
+    moduleEntryId: entry.id,
+    shell: {shellConfig: config, updateEntryInline: (id, settings) => { writes.push(JSON.parse(JSON.stringify(settings))); return true }},
+  })
+  state.persistReceiverEnabled(false)
+  assert.deepEqual(writes, [{tooltip: "keep me", receiverEnabled: false}],
+    "persisting the receiver must not drop unrelated inline settings")
 }
 
 assert.match(source,


### PR DESCRIPTION
## The bug

On a multi-monitor setup, Nearby reports **"Nearby backend could not start. Run the Nearby installer again or build it with ./build.sh."** on one bar while working normally on another.

The bar instantiates its widgets once per screen (`Bar.qml`: `Variants` over `Quickshell.screens`), so `Panel.qml` is built once per monitor and each copy starts its own helper from its own `Process`. The helper binds the LocalSend port, so every copy after the first exits with `EADDRINUSE`:

```
WARN qml: nearby backend Error: receiver could not start
WARN qml: nearby backend     0: IO error: Address already in use (os error 98)
```

The `oma.nearby` IPC target had the same cause — registered once per monitor, and the shell keeps only the first:

```
WARN scene: QML IpcHandler at .../Panel.qml[98:3]: Handler was registered but will not
be used because another handler is registered for target oma.nearby
```

Reinstalling or rebuilding, which the message advises, cannot help: the binary is fine and the port is held by another copy of the same plugin.

## The fix

Move the helper, the transfer state machine, and the IPC target into a `service` entry point. The shell loads a `service` kind **exactly once per session** (`shell.qml: ensureService`), so there is one helper regardless of how many screens are connected, and each bar widget becomes a view that owns only its own cursor and popup.

Third-party services are enabled by presence in `shell.json`, and `PluginRegistry.isEnabled` resolves that through `findEntryLocation`, which searches `bar.layout`. An existing Nearby bar entry therefore enables the service with no user config change.

Because one engine cannot reach into a particular popup, the seams are one-way:

- the engine **signals**; each view moves its own cursor, clears its own PIN field, and takes its own focus
- discovery follows the popup and there is one popup per monitor, so the engine **counts open views** and stops discovery when the last one closes
- `open`/`close`/`toggle` are still per-monitor actions, so they are handed back to the shell, which routes them through the bar to the **focused** screen rather than to whichever instance claimed the target

`Panel.qml` keeps the same property names for engine state, so the popup markup is unchanged and the diff stays readable.

## Second commit: saying what actually failed

Two distinct failures were reported as one, and the advice fitted neither.

- A helper that exits **before** announcing itself returned early from `handleBackendExit`, skipping the retry schedule entirely and reporting a permanent failure on the first exit. It now retries on the same bounded schedule as a receiver that stops later — which is what `ROBUSTNESS.md` item 8 already describes ("a permanent port conflict must stop after four retries"). Toggling the receiver off and on resets that budget, so recovery no longer needs a shell restart.
- The reinstall advice moved to the case it does fix: a helper binary that is **missing** and never launches. That never reaches `onExited` at all — Quickshell reports a command it could not launch by returning `running` to false without an exit code, the way the file chooser and clipboard readers already handle it. Previously this case sat on "Starting receiver…" indefinitely.
- Helper side: a bind failure surfaces as an `io::Error` several layers down, so the whole error chain is searched for `AddrInUse` and the message names the port instead of passing generic context along.

## Validation

Full suite from `AGENTS.md`, all passing:

```
node tests/model.test.js
node tests/panel-state.test.js
node tests/service-state.test.js
cargo fmt --manifest-path backend/Cargo.toml --all -- --check
cargo check --locked --manifest-path backend/Cargo.toml
cargo test --locked --manifest-path backend/Cargo.toml          # 25 passed
cargo test --locked --manifest-path backend/vendor/localsend-rs/Cargo.toml --features https
```

The regression tests fail against pre-fix code for the reported reason:

```
AssertionError: the widget must not spawn the helper: one would be started per monitor
```

The retry change was isolated by running both versions of `handleBackendExit`: pre-fix schedules **0** retries and reports the reinstall message; post-fix schedules the first of four.

`tests/service-state.test.js` carries the state-machine coverage that moved out of `tests/panel-state.test.js`, which now covers the view: cursor dispatch, chooser/clipboard guards, the open-view claim, and degrading safely when no engine is present. CI runs the new file.

### Manual smoke test

Two monitors (`HDMI-A-1` + `DP-1`), Omarchy shell, real hardware:

| | before | after |
|---|---|---|
| helper processes | 2 | **1** |
| duplicate `IpcHandler` warnings | 1 per shell start | **0** |
| `EADDRINUSE` errors | 1 per shell start | **0** |
| widgets rendered | 2 (one showing the error) | **2, both `visible: true`** |

`omarchy-shell oma.nearby status` returns `{"enabled":true,"ready":true,"running":true,"devices":0}`; `open`/`close`/`toggle` return `ok` and discovery starts and stops with the popup.

Not tested: transfers against a real LocalSend peer, and PIN/interop paths. Those were unchanged by this PR beyond the move, but they were not exercised on a device.

## Notes for review

- **New files need a shell restart, not a hot reload.** Installing this over a running shell first failed with `service plugin load failed for oma.nearby: Service.qml: File name case mismatch` — Qt's cached directory listing for the plugin directory predates the new file, and `rescanPlugins` does not clear it. `omarchy restart shell` resolves it. Worth a line in the release notes, since `omarchy plugin update` users will hit it.
- Versions advanced to `1.0.6-dev` in `manifest.json`, `backend/Cargo.toml` and `Cargo.lock` together, per the release rules.
- `AGENTS.md` and `ci.yml` were updated to register the new test file and describe the service/view split. Happy to drop those hunks if you would rather keep that file yours.
