### PR TITLE
fix: report receiver port conflicts explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Report a confirmed local port conflict from a structured helper event instead
+  of treating every failure before receiver startup as port 53317 being busy.
 - Run one helper per shell session instead of one per monitor. The bar builds a
   widget for every screen, so on a multi-monitor setup each extra copy started
   its own helper, lost the race for the LocalSend port, and reported "Nearby

--- a/Service.qml
+++ b/Service.qml
@@ -73,6 +73,8 @@ Item {
   property bool shutdownPending: false
   property bool backendAcceptedThisRun: false
   property bool backendVersionMismatch: false
+  property string backendStartupFailureCode: ""
+  property int backendStartupFailurePort: 0
 
   // Discovery follows the popup, and the popup exists once per monitor, so
   // openness is a count rather than a flag: discovery runs while any view is
@@ -272,14 +274,18 @@ Item {
     if (!receiverEnabled) { statusText="Turned off"; errorText=""; return }
     if (backendVersionMismatch) return
     if (!backendAcceptedThisRun) {
-      // The helper ran and left before announcing itself. It reports the
-      // reason on stderr; the one a user can act on is a port already taken by
-      // another LocalSend receiver. Retry on the same bounded schedule as a
-      // receiver that dropped later, so a port that frees up is picked back up
-      // and a port that never does stops after four attempts.
-      errorText = backendRestart.attempts < 4
-        ? "Nearby receiver could not start. Retrying…"
-        : "Nearby receiver could not start. Another LocalSend app may be holding port 53317."
+      // An early exit alone does not identify its cause. The helper reports a
+      // confirmed bind conflict as a structured event before it exits; all
+      // other pre-ready failures remain generic. Both keep the existing
+      // bounded retry schedule so a transient conflict can recover.
+      if (backendRestart.attempts < 4) {
+        errorText = "Nearby receiver could not start. Retrying…"
+      } else if (backendStartupFailureCode === "receiver_port_in_use") {
+        var port = backendStartupFailurePort > 0 ? backendStartupFailurePort : 53317
+        errorText = "LocalSend receiver port " + port + " is already in use. Another LocalSend receiver on this computer may be running. Quit it and enable Nearby again."
+      } else {
+        errorText = "Nearby receiver could not start."
+      }
       statusText=errorText
     } else {
       errorText=code===0 ? "Receiver stopped" : "Receiver unavailable"
@@ -291,7 +297,11 @@ Item {
   function handleEvent(event) {
     if (!event || !event.event) return
     if (backendVersionMismatch && event.event !== "ready") return
-    if (event.event === "ready") {
+    if (event.event === "startup_failed") {
+      backendStartupFailureCode=String(event.code || "")
+      backendStartupFailurePort=Number(event.port) || 0
+    }
+    else if (event.event === "ready") {
       if (!Model.helperVersionMatches(pluginVersion, event.helperVersion)) {
         backendReady=false
         backendVersionMismatch=true
@@ -355,6 +365,8 @@ Item {
       backend.launched=true
       root.backendAcceptedThisRun=false
       root.backendVersionMismatch=false
+      root.backendStartupFailureCode=""
+      root.backendStartupFailurePort=0
     }
     // A helper that is missing rather than failing never reaches onExited:
     // Quickshell returns running to false without an exit code, the same way

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
+use std::io::Write;
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
@@ -38,6 +39,16 @@ fn caused_by_port_in_use(error: &anyhow::Error) -> bool {
         cause
             .downcast_ref::<std::io::Error>()
             .is_some_and(|io| io.kind() == std::io::ErrorKind::AddrInUse)
+    })
+}
+
+fn startup_failure_event(error: &anyhow::Error) -> Option<Value> {
+    caused_by_port_in_use(error).then(|| {
+        json!({
+            "event": "startup_failed",
+            "code": "receiver_port_in_use",
+            "port": NEARBY_PORT,
+        })
     })
 }
 
@@ -775,7 +786,11 @@ async fn main() -> Result<()> {
             // A taken port is the one startup failure with an obvious remedy,
             // so it is worth saying out loud. Reinstalling the plugin, which a
             // generic failure used to suggest, never frees it.
-            if caused_by_port_in_use(&error) {
+            if let Some(event) = startup_failure_event(&error) {
+                emit(event);
+                if let Err(flush_error) = std::io::stdout().flush() {
+                    eprintln!("could not flush startup failure event: {flush_error}");
+                }
                 return Err(error.context(format!(
                     "receiver could not start: port {NEARBY_PORT} is already in use by another LocalSend receiver"
                 )));
@@ -962,6 +977,27 @@ mod tests {
         let wrapped = anyhow::Error::new(denied).context("IO error");
         assert!(!caused_by_port_in_use(&wrapped));
         assert!(!caused_by_port_in_use(&anyhow!("TLS identity unavailable")));
+    }
+
+    #[test]
+    fn port_in_use_has_a_structured_startup_failure_event() {
+        let bind = std::io::Error::new(std::io::ErrorKind::AddrInUse, "localized message");
+        let wrapped = anyhow::Error::new(bind).context("receiver could not start");
+        assert_eq!(
+            startup_failure_event(&wrapped),
+            Some(json!({
+                "event": "startup_failed",
+                "code": "receiver_port_in_use",
+                "port": 53317,
+            }))
+        );
+    }
+
+    #[test]
+    fn generic_startup_failure_has_no_port_event() {
+        let denied = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let wrapped = anyhow::Error::new(denied).context("receiver could not start");
+        assert_eq!(startup_failure_event(&wrapped), None);
     }
 
     #[test]

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -33,6 +33,8 @@ assert.match(source, /onRunningChanged:\s*\{[\s\S]*?if \(backend\.launched\) ret
   "a helper that never launched must be reported from onRunningChanged")
 assert.match(source, /Run the Nearby installer again or build it with \.\/build\.sh\./,
   "the reinstall hint belongs to the missing-helper case")
+assert.match(source, /onStarted:\s*\{[\s\S]*?backendStartupFailureCode=""[\s\S]*?backendStartupFailurePort=0/,
+  "each helper attempt must discard a stale startup cause before it runs")
 
 function extractFunction(name) {
   const marker = `function ${name}`
@@ -106,6 +108,8 @@ function engine(initial = {}) {
     shutdownPending: false,
     pluginVersion: "1.0.4",
     backendVersionMismatch: false,
+    backendStartupFailureCode: "",
+    backendStartupFailurePort: 0,
     backendReady: true,
     backendAcceptedThisRun: true,
     receiverEnabled: true,
@@ -410,9 +414,9 @@ function incoming(requestId, sender = requestId) {
 }
 
 {
-  // A helper that exits before announcing itself is the port-conflict case.
-  // It used to report a permanent failure and skip the retry schedule, so a
-  // port that freed up was never picked back up.
+  // A helper that exits before announcing itself still uses the bounded retry
+  // schedule. Its cause is independent: an early exit is not, by itself,
+  // evidence that the LocalSend port is occupied.
   const restarts = []
   const state = engine({
     backendAcceptedThisRun: false,
@@ -432,8 +436,38 @@ function incoming(requestId, sender = requestId) {
     backendRestart: {attempts: 4, interval: 0, restart: () => { throw new Error("must not retry") }, stop: () => {}},
   })
   state.handleBackendExit(1)
+  assert.match(state.errorText, /could not start/i)
+  assert.doesNotMatch(state.errorText, /53317|LocalSend/i,
+    "an unknown pre-ready failure must remain generic")
+}
+
+{
+  const restarts = []
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 0, interval: 0, restart() { restarts.push(this.attempts) }, stop: () => {}},
+  })
+  state.handleEvent({event: "startup_failed", code: "receiver_port_in_use", port: 53317})
+  assert.equal(state.backendStartupFailureCode, "receiver_port_in_use")
+  assert.equal(state.backendStartupFailurePort, 53317)
+  state.handleBackendExit(1)
+  assert.equal(state.backendRestart.attempts, 1,
+    "a confirmed port conflict must preserve bounded retries")
+  assert.deepEqual(restarts, [1])
+}
+
+{
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 4, interval: 0, restart: () => { throw new Error("must not retry") }, stop: () => {}},
+  })
+  state.handleEvent({event: "startup_failed", code: "receiver_port_in_use", port: 53317})
+  state.handleBackendExit(1)
   assert.match(state.errorText, /53317/,
-    "a port conflict that outlasts the retry schedule must name the port it lost")
+    "a confirmed port conflict that outlasts retries must name the port")
+  assert.match(state.errorText, /another LocalSend receiver/i)
+  assert.match(state.errorText, /quit it|close it/i,
+    "the final message must tell the user how to release the port")
 }
 
 {


### PR DESCRIPTION
## Summary

- emit a structured `startup_failed` event when the receiver bind fails with typed `AddrInUse`
- show the port-specific guidance only for the confirmed `receiver_port_in_use` cause
- keep unknown pre-ready failures generic and preserve the existing bounded retry policy
- reset the startup cause for every helper attempt so stale failures cannot leak across retries

## Why

The helper already classified a wrapped `std::io::ErrorKind::AddrInUse`, but only reported it on stderr. The Service therefore treated every exit before `ready` as a likely conflict on port 53317. This keeps stderr diagnostic-only and sends the actionable cause through the existing JSON event channel.

## Validation

- `node tests/model.test.js`
- `node tests/panel-state.test.js`
- `node tests/service-state.test.js`
- `cargo fmt --manifest-path backend/Cargo.toml --all -- --check`
- `cargo check --locked --manifest-path backend/Cargo.toml`
- `cargo test --locked --manifest-path backend/Cargo.toml` (27 passed)
- `cargo test --locked --manifest-path backend/vendor/localsend-rs/Cargo.toml --features https` (102 passed, 1 live E2E ignored)
- `git diff --check`

A real local conflict was reproduced with an existing listener on `0.0.0.0:53317`. The helper emitted `receiver_port_in_use` before exit, a Quickshell harness confirmed the event reached `SplitParser` before `onExited`, and the helper reached `ready` after the port was released.

## Scope

No LocalSend protocol, TLS, discovery, receiver-port, retry-count, transfer, or multi-monitor architecture changes.