### PR TITLE
release: prepare v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.0.6
 
 - Report a confirmed local port conflict from a structured helper event instead
   of treating every failure before receiver startup as port 53317 being busy.

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "omarchy-nearby-helper"
-version = "1.0.6-dev"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "localsend-rs",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omarchy-nearby-helper"
-version = "1.0.6-dev"
+version = "1.0.6"
 edition = "2024"
 license = "MIT"
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "oma.nearby",
   "name": "Nearby",
-  "version": "1.0.6-dev",
+  "version": "1.0.6",
   "author": "jfg96",
   "description": "Native nearby sharing compatible with the LocalSend protocol",
   "kinds": [


### PR DESCRIPTION
## Summary

- finalize `manifest.json` and the Rust package at `1.0.6`
- update the lockfile to the matching stable version
- promote the current Unreleased changelog to `1.0.6`

## Validation

- all three Node suites passed
- Rust formatting and locked build check passed
- helper tests: 27 passed
- vendored LocalSend tests: 102 passed, 1 live E2E ignored
- version consistency and `git diff --check` passed

This PR contains release metadata only. The `v1.0.6` tag will be created only after this exact preparation has passed CI and merged.