### PR TITLE
fix: restart receiver after exhausted startup retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Keep the helper's running state bound to the receiver setting across startup
+  retries, so toggling Nearby off and on can recover after a port conflict.
+
 ## 1.0.6
 
 - Report a confirmed local port conflict from a structured helper event instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.0.7
 
 - Keep the helper's running state bound to the receiver setting across startup
   retries, so toggling Nearby off and on can recover after a port conflict.

--- a/Service.qml
+++ b/Service.qml
@@ -144,6 +144,14 @@ Item {
     if (!backend.running) return
     backend.write(JSON.stringify(command) + "\n")
   }
+  function bindBackendRunning() {
+    // Assigning a plain `true` here removes the declarative binding from
+    // Process.running. Reinstall the binding instead so receiver OFF -> ON can
+    // still start the helper after the retry budget has been exhausted.
+    backend.running = Qt.binding(function() {
+      return root.receiverConfigured && root.receiverEnabled && root.pluginVersion !== ""
+    })
+  }
   // receiverEnabled follows the entry, so writing the entry is what turns the
   // receiver on or off. There is no second copy of the state to keep in step.
   function persistReceiverEnabled(enabled) {
@@ -385,6 +393,6 @@ Item {
     }
     onExited: function(code) { root.handleBackendExit(code) }
   }
-  Timer { id: backendRestart; property int attempts: 0; interval: 1000; repeat: false; onTriggered: if (root.receiverEnabled && !backend.running) backend.running=true }
+  Timer { id: backendRestart; property int attempts: 0; interval: 1000; repeat: false; onTriggered: if (root.receiverEnabled && !backend.running) root.bindBackendRunning() }
   Timer { id: receiverShutdownFallback; interval: 250; repeat: false; onTriggered: root.finishReceiverShutdown() }
 }

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "omarchy-nearby-helper"
-version = "1.0.6"
+version = "1.0.7-dev"
 dependencies = [
  "anyhow",
  "localsend-rs",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "omarchy-nearby-helper"
-version = "1.0.7-dev"
+version = "1.0.7"
 dependencies = [
  "anyhow",
  "localsend-rs",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omarchy-nearby-helper"
-version = "1.0.6"
+version = "1.0.7-dev"
 edition = "2024"
 license = "MIT"
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omarchy-nearby-helper"
-version = "1.0.7-dev"
+version = "1.0.7"
 edition = "2024"
 license = "MIT"
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "oma.nearby",
   "name": "Nearby",
-  "version": "1.0.6",
+  "version": "1.0.7-dev",
   "author": "jfg96",
   "description": "Native nearby sharing compatible with the LocalSend protocol",
   "kinds": [

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "oma.nearby",
   "name": "Nearby",
-  "version": "1.0.7-dev",
+  "version": "1.0.7",
   "author": "jfg96",
   "description": "Native nearby sharing compatible with the LocalSend protocol",
   "kinds": [

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -35,6 +35,10 @@ assert.match(source, /Run the Nearby installer again or build it with \.\/build\
   "the reinstall hint belongs to the missing-helper case")
 assert.match(source, /onStarted:\s*\{[\s\S]*?backendStartupFailureCode=""[\s\S]*?backendStartupFailurePort=0/,
   "each helper attempt must discard a stale startup cause before it runs")
+assert.match(source, /id: backendRestart[\s\S]*?onTriggered:[^\n]*bindBackendRunning\(\)/,
+  "the retry timer must restore the Process.running binding")
+assert.doesNotMatch(source, /backend\.running\s*=\s*true/,
+  "a plain retry assignment would permanently remove the Process.running binding")
 
 function extractFunction(name) {
   const marker = `function ${name}`
@@ -74,7 +78,7 @@ function backendEligible(state) {
 
 const functionNames = [
   "viewOpened", "viewClosed",
-  "send", "persistReceiverEnabled", "toggleReceiver", "finishReceiverShutdown",
+  "send", "bindBackendRunning", "persistReceiverEnabled", "toggleReceiver", "finishReceiverShutdown",
   "startDiscovery", "forceFullDiscovery", "stopDiscovery", "chooseDevice", "clearTarget",
   "failWith", "cancelOutgoing", "noteTextCopied",
   "clearPendingOutgoing", "dispatchPendingOutgoing", "beginOutgoing", "retryWithPin",
@@ -91,6 +95,7 @@ function engine(initial = {}) {
     Model,
     Date: {now: () => 1000},
     Quickshell: {execDetached: () => {}},
+    Qt: {binding: callback => ({callback})},
     backend: {running: true, write: line => sent.push(JSON.parse(line))},
     backendRestart: {attempts: 0, interval: 0, restart: () => {}, stop: () => {}},
     receiverShutdownFallback: {stop: () => {}, restart: () => {}},
@@ -140,6 +145,22 @@ function engine(initial = {}) {
   context.cursors = cursors
   context.signals = signals
   return context
+}
+
+{
+  // A retry must reinstall the declarative Process.running binding. Assigning
+  // a plain true removes it, so a later OFF -> ON toggle cannot start the
+  // helper after a port conflict has exhausted the retry budget.
+  const state = engine({backend: {running: false, write: () => {}}})
+  state.root = state
+  state.bindBackendRunning()
+  assert.equal(typeof state.backend.running.callback, "function")
+  assert.equal(state.backend.running.callback(), true)
+  state.receiverEnabled = false
+  assert.equal(state.backend.running.callback(), false)
+  state.receiverEnabled = true
+  assert.equal(state.backend.running.callback(), true,
+    "the restored binding must make OFF -> ON eligible to start again")
 }
 
 function incoming(requestId, sender = requestId) {


### PR DESCRIPTION
## Summary

- reinstall the declarative `Process.running` binding on startup retries instead of replacing it with a plain boolean
- allow receiver OFF → ON to start the helper after a port conflict exhausts the retry budget
- add focused regression coverage and prepare the stable `1.0.7` release

## Root cause

The retry timer assigned `backend.running = true`. In QML that permanently removed the original binding to receiver configuration. Once retries were exhausted, toggling the receiver changed `receiverEnabled` but no longer affected `Process.running`; restarting Quickshell only appeared to fix it because it reconstructed the binding.

## Validation

- all three Node suites passed
- Rust formatting and locked build check passed
- helper tests: 27 passed
- vendored LocalSend tests: 102 passed, 1 live E2E ignored
- real reproduction: five `AddrInUse` failures exhausted the retry budget, port 53317 was released, and OFF → ON recovered immediately without changing the Quickshell PID

No protocol, TLS, discovery, transfer, port, retry-count, retry-timing, or multi-monitor changes.