### PR TITLE
feat: add incoming PIN protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           [[ "$(git rev-list -n 1 "$GITHUB_REF_NAME")" == "$GITHUB_SHA" ]]
 
       - name: Test frontend model
-        run: node tests/model.test.js && node tests/panel-state.test.js
+        run: node tests/model.test.js && node tests/panel-state.test.js && node tests/service-state.test.js
 
       - name: Check Rust formatting
         run: cargo fmt --manifest-path backend/Cargo.toml --all -- --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.1.0-dev
+
+- Add a user-configured, persistent PIN for incoming text and file transfers.
+  PIN changes take effect without restarting the receiver or interrupting an
+  already authorized transfer, while normal Accept/Decline remains required.
+- Match LocalSend's three-attempt receiver lockout semantics and keep failure
+  tracking bounded per source IP.
+- Accept and correctly encode general PIN values when sending to LocalSend,
+  instead of restricting the prompt to numeric values.
+- Store incoming PIN configuration in a private atomic settings file, load it
+  before receiver startup and fail closed if that security state is invalid.
+
 ## 1.0.7
 
 - Keep the helper's running state bound to the receiver setting across startup

--- a/Panel.qml
+++ b/Panel.qml
@@ -71,6 +71,7 @@ Panel {
       if (!backendReady) return errorText || statusText
       return nearbyPhrases[nearbyPhraseIndex % nearbyPhrases.length]
     }
+    if (viewState.indexOf("incoming_pin_") === 0) return "Receiver security"
     if (viewState === "target") return "Ready to receive"
     return statusText
   }
@@ -136,15 +137,15 @@ Panel {
       if (dy !== 0) selectedIndex = Math.max(-1, Math.min(lastNearbyIndex, selectedIndex + dy))
       return
     }
-    var count = viewState === "target" ? 2 : ((viewState === "incoming" || viewState === "text" || viewState === "incoming_pin_disable") ? 2 : (viewState === "incoming_pin_settings" ? (incomingPinEnabled ? 2 : 1) : 1))
+    var count = viewState === "target" ? 3 : ((viewState === "incoming" || viewState === "text" || viewState === "incoming_pin_disable") ? 2 : (viewState === "incoming_pin_settings" ? (incomingPinEnabled ? 3 : 2) : 1))
     if (count > 0 && dy !== 0) selectedIndex = Math.max(0, Math.min(count - 1, selectedIndex + dy))
   }
   function activateCursor() {
     if (viewState === "nearby") selectedIndex < 0 ? toggleReceiver() : (selectedIndex === devices.length ? forceFullDiscovery() : (selectedIndex === devices.length+1 ? openIncomingPinSettings() : chooseDevice(selectedIndex)))
-    else if (viewState === "target") selectedIndex === 0 ? selectFiles() : sendClipboard()
+    else if (viewState === "target") selectedIndex === 0 ? selectFiles() : (selectedIndex === 1 ? sendClipboard() : goBack())
     else if (viewState === "incoming") selectedIndex === 0 ? declineIncoming() : acceptIncoming()
     else if (viewState === "text") { if(selectedIndex===0)copyReceivedText(); else finishText() }
-    else if (viewState === "incoming_pin_settings") incomingPinEnabled ? (selectedIndex===0?beginIncomingPinEdit():requestDisableIncomingPin()) : beginIncomingPinEdit()
+    else if (viewState === "incoming_pin_settings") incomingPinEnabled ? (selectedIndex===0?beginIncomingPinEdit():(selectedIndex===1?requestDisableIncomingPin():goBack())) : (selectedIndex===0?beginIncomingPinEdit():goBack())
     else if (viewState === "incoming_pin_disable") selectedIndex===0 ? cancelIncomingPinSettings() : confirmDisableIncomingPin()
     else if (viewState === "sending") cancelOutgoing()
     else if (viewState === "success" || viewState === "error") finishTerminal()
@@ -282,6 +283,7 @@ Panel {
           PanelSectionHeader { text:"SEND"; foreground:root.foreground; fontFamily:root.fontFamily }
           Button { width:parent.width; leftAlign:true; iconText:"󰈔"; text:"Send files"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.selectFiles() }
           Button { width:parent.width; leftAlign:true; iconText:"󰅇"; text:"Send clipboard"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=1}}; onClicked:root.sendClipboard() }
+          Button { width:parent.width; leftAlign:true; bordered:false; iconText:"󰅁"; text:"Back"; foreground:root.dim; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===2; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=2}}; onClicked:root.goBack() }
         }
 
         Column {
@@ -304,11 +306,12 @@ Panel {
           visible: root.viewState === "incoming_pin_settings"; width:parent.width; spacing:Style.space(8)
           PanelSectionHeader { text:"INCOMING TRANSFERS"; foreground:root.foreground; fontFamily:root.fontFamily }
           Text { width:parent.width; text:root.incomingPinEnabled?"PIN protection is enabled":"PIN protection is disabled"; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body }
-          Button { visible:!root.incomingPinEnabled; width:parent.width; text:"Enable PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onClicked:root.beginIncomingPinEdit() }
+          Button { visible:!root.incomingPinEnabled; width:parent.width; text:"Enable PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.beginIncomingPinEdit() }
           Row { visible:root.incomingPinEnabled; width:parent.width; spacing:Style.space(8)
-            Button { width:(parent.width-parent.spacing)/2; text:"Change PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onClicked:root.beginIncomingPinEdit() }
-            Button { width:(parent.width-parent.spacing)/2; text:"Disable PIN"; bordered:true; foreground:root.urgent; hasCursor:root.cursorActive&&root.selectedIndex===1; onClicked:root.requestDisableIncomingPin() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Change PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.beginIncomingPinEdit() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Disable PIN"; bordered:true; foreground:root.urgent; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=1}}; onClicked:root.requestDisableIncomingPin() }
           }
+          Button { width:parent.width; leftAlign:true; bordered:false; iconText:"󰅁"; text:"Back"; foreground:root.dim; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===(root.incomingPinEnabled?2:1); onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=root.incomingPinEnabled?2:1}}; onClicked:root.goBack() }
           Text { visible:root.incomingPinError!==""; width:parent.width; text:root.incomingPinError; color:root.urgent; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
         }
 
@@ -335,8 +338,8 @@ Panel {
           Text { width:parent.width; text:"New incoming requests will no longer require a PIN."; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
           Text { visible:root.incomingPinError!==""; width:parent.width; text:root.incomingPinError; color:root.urgent; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
           Row { width:parent.width; spacing:Style.space(8)
-            Button { width:(parent.width-parent.spacing)/2; text:"Cancel"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.dim; hasCursor:root.cursorActive&&root.selectedIndex===0; onClicked:root.cancelIncomingPinSettings() }
-            Button { width:(parent.width-parent.spacing)/2; text:root.incomingPinUpdating?"Disabling…":"Disable"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.urgent; hasCursor:root.cursorActive&&root.selectedIndex===1; onClicked:root.confirmDisableIncomingPin() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Cancel"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.dim; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.cancelIncomingPinSettings() }
+            Button { width:(parent.width-parent.spacing)/2; text:root.incomingPinUpdating?"Disabling…":"Disable"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.urgent; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=1}}; onClicked:root.confirmDisableIncomingPin() }
           }
         }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -274,9 +274,7 @@ Panel {
           PanelSectionHeader { text:"RECEIVER PIN"; foreground:root.foreground; fontFamily:root.fontFamily }
           Text { width:parent.width; text:"This receiver requires a PIN"; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body }
           TextField {
-            id: pinInput; width:parent.width; password:true; placeholderText:"PIN"; maximumLength:32; foreground:root.foreground; font.family:root.fontFamily; font.pixelSize:Style.font.body
-            inputMethodHints: Qt.ImhDigitsOnly
-            validator: RegularExpressionValidator { regularExpression: /[0-9]*/ }
+            id: pinInput; width:parent.width; password:true; placeholderText:"PIN"; foreground:root.foreground; font.family:root.fontFamily; font.pixelSize:Style.font.body
             onAccepted: root.retryWithPin()
             Keys.onPressed: function(event) { if(event.key===Qt.Key_Escape){root.cancelPin();event.accepted=true} }
           }

--- a/Panel.qml
+++ b/Panel.qml
@@ -46,6 +46,9 @@ Panel {
   readonly property string transferName: engine ? engine.transferName : ""
   readonly property string transferPeer: engine ? engine.transferPeer : ""
   readonly property string pinError: engine ? engine.pinError : ""
+  readonly property bool incomingPinEnabled: engine ? engine.incomingPinEnabled : false
+  readonly property bool incomingPinUpdating: engine ? engine.incomingPinUpdating : false
+  readonly property string incomingPinError: engine ? engine.incomingPinError : ""
 
   // Cursor and popup focus are per monitor, so they stay here.
   property int selectedIndex: 0
@@ -93,6 +96,8 @@ Panel {
     function onCursorRequested(index) { root.selectedIndex = index }
     function onPinCleared() { pinInput.text = "" }
     function onPinFocusRequested() { if (root.opened) Qt.callLater(function(){ pinInput.forceActiveFocus() }) }
+    function onIncomingPinCleared() { incomingPinInput.text = "" }
+    function onIncomingPinFocusRequested() { if (root.opened) Qt.callLater(function(){ incomingPinInput.forceActiveFocus() }) }
     function onFocusRestoreRequested() { if (root.opened) Qt.callLater(function(){ keyCatcher.forceActiveFocus() }) }
   }
 
@@ -107,10 +112,16 @@ Panel {
   function cancelOutgoing() { if (engine) engine.cancelOutgoing() }
   function cancelPin() { if (engine) engine.cancelPin() }
   function retryWithPin() { if (engine) engine.retryWithPin(String(pinInput.text || "")) }
+  function openIncomingPinSettings() { if (engine) engine.openIncomingPinSettings() }
+  function beginIncomingPinEdit() { if (engine) engine.beginIncomingPinEdit() }
+  function requestDisableIncomingPin() { if (engine) engine.requestDisableIncomingPin() }
+  function cancelIncomingPinSettings() { if (engine) engine.cancelIncomingPinSettings() }
+  function submitIncomingPin() { if (engine) engine.submitIncomingPin(String(incomingPinInput.text || "")) }
+  function confirmDisableIncomingPin() { if (engine) engine.confirmDisableIncomingPin() }
   function failWith(message) { if (engine) engine.failWith(message) }
   function noteTextCopied() { if (engine) engine.noteTextCopied() }
   function beginOutgoing(pending) { if (engine) engine.beginOutgoing(pending) }
-  function goBack() { if (viewState === "pin") cancelPin(); else if (viewState === "target") { if (engine) engine.clearTarget() } else close() }
+  function goBack() { if (viewState === "pin") cancelPin(); else if (viewState.indexOf("incoming_pin_")===0) cancelIncomingPinSettings(); else if (viewState === "target") { if (engine) engine.clearTarget() } else close() }
 
   // The chooser and the clipboard belong to the monitor the user acted on, so
   // they stay with the view and hand their result to the engine.
@@ -121,17 +132,20 @@ Panel {
   function moveCursor(dx, dy) {
     cursorActive = true
     if (viewState === "nearby") {
-      if (dy !== 0) selectedIndex = Math.max(-1, Math.min(devices.length, selectedIndex + dy))
+      var lastNearbyIndex=receiverEnabled&&backendReady ? devices.length+1 : Math.max(-1,devices.length-1)
+      if (dy !== 0) selectedIndex = Math.max(-1, Math.min(lastNearbyIndex, selectedIndex + dy))
       return
     }
-    var count = viewState === "target" ? 2 : ((viewState === "incoming" || viewState === "text") ? 2 : 1)
+    var count = viewState === "target" ? 2 : ((viewState === "incoming" || viewState === "text" || viewState === "incoming_pin_disable") ? 2 : (viewState === "incoming_pin_settings" ? (incomingPinEnabled ? 2 : 1) : 1))
     if (count > 0 && dy !== 0) selectedIndex = Math.max(0, Math.min(count - 1, selectedIndex + dy))
   }
   function activateCursor() {
-    if (viewState === "nearby") selectedIndex < 0 ? toggleReceiver() : (selectedIndex === devices.length ? forceFullDiscovery() : chooseDevice(selectedIndex))
+    if (viewState === "nearby") selectedIndex < 0 ? toggleReceiver() : (selectedIndex === devices.length ? forceFullDiscovery() : (selectedIndex === devices.length+1 ? openIncomingPinSettings() : chooseDevice(selectedIndex)))
     else if (viewState === "target") selectedIndex === 0 ? selectFiles() : sendClipboard()
     else if (viewState === "incoming") selectedIndex === 0 ? declineIncoming() : acceptIncoming()
     else if (viewState === "text") { if(selectedIndex===0)copyReceivedText(); else finishText() }
+    else if (viewState === "incoming_pin_settings") incomingPinEnabled ? (selectedIndex===0?beginIncomingPinEdit():requestDisableIncomingPin()) : beginIncomingPinEdit()
+    else if (viewState === "incoming_pin_disable") selectedIndex===0 ? cancelIncomingPinSettings() : confirmDisableIncomingPin()
     else if (viewState === "sending") cancelOutgoing()
     else if (viewState === "success" || viewState === "error") finishTerminal()
   }
@@ -140,7 +154,7 @@ Panel {
     if (opened) {
       cursorActive=false; selectedIndex=-1; nearbyPhraseIndex=0
       syncOpenState()
-      Qt.callLater(function(){ if (root.viewState==="pin") pinInput.forceActiveFocus(); else keyCatcher.forceActiveFocus() })
+      Qt.callLater(function(){ if (root.viewState==="pin") pinInput.forceActiveFocus(); else if(root.viewState==="incoming_pin_edit")incomingPinInput.forceActiveFocus(); else keyCatcher.forceActiveFocus() })
     } else { syncOpenState() }
   }
 
@@ -223,7 +237,7 @@ Panel {
     contentHeight: panel.fittedContentHeight(content.implicitHeight, Style.space(560))
     PanelKeyCatcher {
       id: keyCatcher; anchors.fill: parent
-      blocked: root.viewState==="pin" && pinInput.activeFocus
+      blocked: (root.viewState==="pin" && pinInput.activeFocus)||(root.viewState==="incoming_pin_edit"&&incomingPinInput.activeFocus)
       onMoveRequested: function(dx,dy){root.moveCursor(dx,dy)}
       onActivateRequested: root.activateCursor()
       onCloseRequested: root.goBack()
@@ -231,7 +245,7 @@ Panel {
         id: content; width: parent.width; spacing: Style.space(12)
         PanelHero {
           id: hero
-          title: (root.viewState === "target" || root.viewState === "pin") && root.selectedDevice ? root.selectedDevice.alias : (root.viewState === "incoming" ? "Incoming" : "Nearby")
+          title: root.viewState.indexOf("incoming_pin_")===0 ? "Incoming PIN" : ((root.viewState === "target" || root.viewState === "pin") && root.selectedDevice ? root.selectedDevice.alias : (root.viewState === "incoming" ? "Incoming" : "Nearby"))
           meta: root.heroMetaText
           detail: ""
           foreground: root.foreground; fontFamily: root.fontFamily
@@ -260,6 +274,7 @@ Panel {
             Button { required property var modelData; required property int index; width:parent.width; leftAlign:true; bordered:false; iconText:Model.iconFor(modelData.deviceType); text:modelData.alias; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===index; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=index}}; onClicked:root.chooseDevice(index) }
           }
           Button { visible:root.receiverEnabled&&root.backendReady; width:parent.width; leftAlign:true; bordered:false; iconText:"󰑐"; text:"Search for new devices"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=root.devices.length}}; onClicked:root.forceFullDiscovery() }
+          Button { visible:root.receiverEnabled&&root.backendReady; width:parent.width; leftAlign:true; bordered:false; iconText:"󰌾"; text:"Incoming PIN · "+(root.incomingPinEnabled?"On":"Off"); foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length+1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=root.devices.length+1}}; onClicked:root.openIncomingPinSettings() }
         }
 
         Column {
@@ -282,6 +297,46 @@ Panel {
           Row { width:parent.width; spacing:Style.space(8)
             Button { width:(parent.width-parent.spacing)/2; text:"Cancel"; bordered:true; foreground:root.dim; onClicked:root.cancelPin() }
             Button { width:(parent.width-parent.spacing)/2; text:"Retry"; bordered:true; foreground:root.foreground; onClicked:root.retryWithPin() }
+          }
+        }
+
+        Column {
+          visible: root.viewState === "incoming_pin_settings"; width:parent.width; spacing:Style.space(8)
+          PanelSectionHeader { text:"INCOMING TRANSFERS"; foreground:root.foreground; fontFamily:root.fontFamily }
+          Text { width:parent.width; text:root.incomingPinEnabled?"PIN protection is enabled":"PIN protection is disabled"; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body }
+          Button { visible:!root.incomingPinEnabled; width:parent.width; text:"Enable PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onClicked:root.beginIncomingPinEdit() }
+          Row { visible:root.incomingPinEnabled; width:parent.width; spacing:Style.space(8)
+            Button { width:(parent.width-parent.spacing)/2; text:"Change PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onClicked:root.beginIncomingPinEdit() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Disable PIN"; bordered:true; foreground:root.urgent; hasCursor:root.cursorActive&&root.selectedIndex===1; onClicked:root.requestDisableIncomingPin() }
+          }
+          Text { visible:root.incomingPinError!==""; width:parent.width; text:root.incomingPinError; color:root.urgent; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
+        }
+
+        Column {
+          visible: root.viewState === "incoming_pin_edit"; width:parent.width; spacing:Style.space(8)
+          PanelSectionHeader { text:root.incomingPinEnabled?"CHANGE PIN":"ENABLE PIN"; foreground:root.foreground; fontFamily:root.fontFamily }
+          Text { width:parent.width; text:"Use 1–64 letters, numbers, dot, underscore, tilde or hyphen"; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
+          TextField {
+            id:incomingPinInput; width:parent.width; password:true; placeholderText:"New PIN"; maximumLength:64; enabled:!root.incomingPinUpdating; foreground:root.foreground; font.family:root.fontFamily; font.pixelSize:Style.font.body
+            validator:RegularExpressionValidator { regularExpression:/[A-Za-z0-9._~-]{0,64}/ }
+            onAccepted:root.submitIncomingPin()
+            Keys.onPressed:function(event){if(event.key===Qt.Key_Escape){root.cancelIncomingPinSettings();event.accepted=true}}
+          }
+          Text { visible:root.incomingPinError!==""; width:parent.width; text:root.incomingPinError; color:root.urgent; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
+          Row { width:parent.width; spacing:Style.space(8)
+            Button { width:(parent.width-parent.spacing)/2; text:"Cancel"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.dim; onClicked:root.cancelIncomingPinSettings() }
+            Button { width:(parent.width-parent.spacing)/2; text:root.incomingPinUpdating?"Saving…":"Save"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.foreground; onClicked:root.submitIncomingPin() }
+          }
+        }
+
+        Column {
+          visible: root.viewState === "incoming_pin_disable"; width:parent.width; spacing:Style.space(8)
+          PanelSectionHeader { text:"DISABLE PIN"; foreground:root.foreground; fontFamily:root.fontFamily }
+          Text { width:parent.width; text:"New incoming requests will no longer require a PIN."; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
+          Text { visible:root.incomingPinError!==""; width:parent.width; text:root.incomingPinError; color:root.urgent; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
+          Row { width:parent.width; spacing:Style.space(8)
+            Button { width:(parent.width-parent.spacing)/2; text:"Cancel"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.dim; hasCursor:root.cursorActive&&root.selectedIndex===0; onClicked:root.cancelIncomingPinSettings() }
+            Button { width:(parent.width-parent.spacing)/2; text:root.incomingPinUpdating?"Disabling…":"Disable"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.urgent; hasCursor:root.cursorActive&&root.selectedIndex===1; onClicked:root.confirmDisableIncomingPin() }
           }
         }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -71,7 +71,9 @@ Panel {
       if (!backendReady) return errorText || statusText
       return nearbyPhrases[nearbyPhraseIndex % nearbyPhrases.length]
     }
-    if (viewState.indexOf("incoming_pin_") === 0) return "Receiver security"
+    if (viewState === "incoming_pin_settings") return incomingPinEnabled ? "Protection enabled" : "Protection disabled"
+    if (viewState === "incoming_pin_edit") return incomingPinEnabled ? "Change protection" : "Enable protection"
+    if (viewState === "incoming_pin_disable") return "Confirm disable"
     if (viewState === "target") return "Ready to receive"
     return statusText
   }
@@ -134,7 +136,19 @@ Panel {
     cursorActive = true
     if (viewState === "nearby") {
       var lastNearbyIndex=receiverEnabled&&backendReady ? devices.length+1 : Math.max(-1,devices.length-1)
+      if (dx !== 0 && selectedIndex >= devices.length) {
+        selectedIndex = Math.max(devices.length, Math.min(lastNearbyIndex, selectedIndex + dx))
+        return
+      }
       if (dy !== 0) selectedIndex = Math.max(-1, Math.min(lastNearbyIndex, selectedIndex + dy))
+      return
+    }
+    if (dx !== 0 && (viewState === "incoming" || viewState === "text" || viewState === "incoming_pin_disable")) {
+      selectedIndex = Math.max(0, Math.min(1, selectedIndex + dx))
+      return
+    }
+    if (dx !== 0 && viewState === "incoming_pin_settings" && incomingPinEnabled && selectedIndex < 2) {
+      selectedIndex = Math.max(0, Math.min(1, selectedIndex + dx))
       return
     }
     var count = viewState === "target" ? 3 : ((viewState === "incoming" || viewState === "text" || viewState === "incoming_pin_disable") ? 2 : (viewState === "incoming_pin_settings" ? (incomingPinEnabled ? 3 : 2) : 1))
@@ -267,15 +281,18 @@ Panel {
         PanelSeparator { width: parent.width }
 
         Column {
-          visible: root.viewState === "nearby"; width: parent.width; spacing: Style.space(4)
-          PanelSectionHeader { text: "NEARBY"; foreground:root.foreground; fontFamily:root.fontFamily }
+          visible: root.viewState === "nearby"; width: parent.width; spacing: Style.space(6)
+          PanelSectionHeader { text: "DEVICES"; foreground:root.foreground; fontFamily:root.fontFamily }
           Text { visible: root.devices.length===0; width:parent.width; textFormat:Text.PlainText; text: !root.receiverEnabled ? "Nearby is turned off" : (root.discoveryActive ? "Finding devices…" : (root.backendReady ? "No devices nearby" : root.errorText)); wrapMode:Text.Wrap; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body; topPadding:Style.space(12); bottomPadding:Style.space(12) }
           Repeater {
             model: root.devices
             Button { required property var modelData; required property int index; width:parent.width; leftAlign:true; bordered:false; iconText:Model.iconFor(modelData.deviceType); text:modelData.alias; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===index; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=index}}; onClicked:root.chooseDevice(index) }
           }
-          Button { visible:root.receiverEnabled&&root.backendReady; width:parent.width; leftAlign:true; bordered:false; iconText:"󰑐"; text:"Search for new devices"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=root.devices.length}}; onClicked:root.forceFullDiscovery() }
-          Button { visible:root.receiverEnabled&&root.backendReady; width:parent.width; leftAlign:true; bordered:false; iconText:"󰌾"; text:"Incoming PIN · "+(root.incomingPinEnabled?"On":"Off"); foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length+1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=root.devices.length+1}}; onClicked:root.openIncomingPinSettings() }
+          Row {
+            id:nearbyActions; visible:root.receiverEnabled&&root.backendReady; width:parent.width; spacing:Style.space(8)
+            Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰑐"; text:"Rescan"; tooltipText:"Search for new devices"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=root.devices.length}}; onClicked:root.forceFullDiscovery() }
+            Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰌾"; text:"PIN · "+(root.incomingPinEnabled?"On":"Off"); tooltipText:"Incoming PIN settings"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length+1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=root.devices.length+1}}; onClicked:root.openIncomingPinSettings() }
+          }
         }
 
         Column {
@@ -304,8 +321,6 @@ Panel {
 
         Column {
           visible: root.viewState === "incoming_pin_settings"; width:parent.width; spacing:Style.space(8)
-          PanelSectionHeader { text:"INCOMING TRANSFERS"; foreground:root.foreground; fontFamily:root.fontFamily }
-          Text { width:parent.width; text:root.incomingPinEnabled?"PIN protection is enabled":"PIN protection is disabled"; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body }
           Button { visible:!root.incomingPinEnabled; width:parent.width; text:"Enable PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.beginIncomingPinEdit() }
           Row { visible:root.incomingPinEnabled; width:parent.width; spacing:Style.space(8)
             Button { width:(parent.width-parent.spacing)/2; text:"Change PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.beginIncomingPinEdit() }
@@ -349,8 +364,8 @@ Panel {
           Text { width:parent.width; textFormat:Text.PlainText; text:root.incoming ? Model.incomingSummary(root.incoming.files)+" · "+Model.formatBytes(root.incoming.total) : ""; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body; elide:Text.ElideRight }
           Text { visible:root.incomingQueue.length>1; width:parent.width; text:(root.incomingQueue.length-1)+(root.incomingQueue.length===2 ? " more request" : " more requests"); color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body }
           Row { width:parent.width; spacing:Style.space(8)
-            Button { width:(parent.width-parent.spacing)/2; text:"Decline"; foreground:root.urgent; bordered:true; hasCursor:root.cursorActive&&root.selectedIndex===0; onClicked:root.declineIncoming() }
-            Button { width:(parent.width-parent.spacing)/2; text:"Accept"; foreground:root.foreground; bordered:true; hasCursor:root.cursorActive&&root.selectedIndex===1; onClicked:root.acceptIncoming() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Decline"; foreground:root.urgent; bordered:true; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.declineIncoming() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Accept"; foreground:root.foreground; bordered:true; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=1}}; onClicked:root.acceptIncoming() }
           }
         }
 
@@ -375,8 +390,8 @@ Panel {
           PanelSectionHeader { text:"RECEIVED TEXT"; foreground:root.foreground; fontFamily:root.fontFamily }
           Text { width:parent.width; textFormat:Text.PlainText; text:root.incomingText; wrapMode:Text.Wrap; maximumLineCount:6; elide:Text.ElideRight; color:root.foreground; font.family:root.fontFamily; font.pixelSize:Style.font.body }
           Row { width:parent.width; spacing:Style.space(8)
-            Button { width:(parent.width-parent.spacing)/2; text:"Copy"; iconText:"󰆏"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onClicked:{root.copyReceivedText()} }
-            Button { width:(parent.width-parent.spacing)/2; text:"Done"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===1; onClicked:root.finishText() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Copy"; iconText:"󰆏"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:{root.copyReceivedText()} }
+            Button { width:(parent.width-parent.spacing)/2; text:"Done"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=1}}; onClicked:root.finishText() }
           }
         }
       }

--- a/Panel.qml
+++ b/Panel.qml
@@ -121,6 +121,7 @@ Panel {
   function cancelIncomingPinSettings() { if (engine) engine.cancelIncomingPinSettings() }
   function submitIncomingPin() { if (engine) engine.submitIncomingPin(String(incomingPinInput.text || "")) }
   function confirmDisableIncomingPin() { if (engine) engine.confirmDisableIncomingPin() }
+  function clearSecretInputs() { pinInput.text = ""; incomingPinInput.text = "" }
   function failWith(message) { if (engine) engine.failWith(message) }
   function noteTextCopied() { if (engine) engine.noteTextCopied() }
   function beginOutgoing(pending) { if (engine) engine.beginOutgoing(pending) }
@@ -170,7 +171,7 @@ Panel {
       cursorActive=false; selectedIndex=-1; nearbyPhraseIndex=0
       syncOpenState()
       Qt.callLater(function(){ if (root.viewState==="pin") pinInput.forceActiveFocus(); else if(root.viewState==="incoming_pin_edit")incomingPinInput.forceActiveFocus(); else keyCatcher.forceActiveFocus() })
-    } else { syncOpenState() }
+    } else { clearSecretInputs(); syncOpenState() }
   }
 
   Timer {

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ bash /tmp/omarchy-nearby-install.sh
 
 The installer selects a published release, installs the plugin at that exact tag,
 downloads its matching Linux x86_64 helper, verifies the SHA256, and enables
-`oma.nearby`. It does not use `sudo`, install packages, require Rust, or compile
-anything locally.
+`oma.nearby`. Nearby never requests administrator privileges. The installer does
+not install packages, require Rust, or compile anything locally.
 
 Install or reinstall a specific release with:
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The widget is placed in the right section of the bar by default. Remove it with
 - Send one or more files
 - Send clipboard text
 - Receive files and text with explicit accept/decline controls
+- Optionally require a persistent PIN for incoming text and file transfers
 - Transfer progress, completion, cancellation and error states
 - Native Omarchy bar widget and popup
 - HTTPS LocalSend interoperability with certificate fingerprint handling
@@ -82,6 +83,21 @@ requires a Rust toolchain with Cargo.
 Received files are written to the user's Downloads directory. Interrupted receives
 use `.nearby-*.part` files. On startup, Nearby removes only its own partial files
 that are older than 24 hours.
+
+## Incoming PIN protection
+
+Open **Incoming PIN** from Nearby's device list to enable, change or disable
+receiver PIN protection. Nearby accepts 1–64 ASCII letters, numbers, dots,
+underscores, tildes and hyphens for an incoming PIN so official LocalSend
+senders can transmit it reliably.
+
+The sender must provide the correct PIN before Nearby displays the transfer,
+but the local user must still explicitly Accept or Decline it. Changes apply to
+new requests immediately and do not restart discovery or interrupt an already
+authorized transfer. Nearby stores the PIN in
+`$XDG_STATE_HOME/omarchy-nearby/settings.json` (falling back to
+`~/.local/state/omarchy-nearby/settings.json`) with user-only permissions and
+never displays the saved value again.
 
 ## Architecture
 
@@ -214,6 +230,12 @@ A larger manual interoperability and robustness checklist is kept in
 Nearby validates transfer paths and writes incoming files through temporary partial
 files before atomic finalization. TLS fingerprints are used for peer connections
 where the LocalSend protocol exposes them.
+
+Incoming PIN protection is an additional authorization gate, not authenticated
+pairing and not a replacement for TLS or local Accept/Decline. Three incorrect
+PIN submissions from one IP cause subsequent requests from that IP to receive
+LocalSend's `429 Too Many Requests` response until the receiver security state
+changes or the receiver restarts.
 
 LocalSend discovery itself is LAN discovery and should not be treated as an
 authenticated pairing mechanism. Use Nearby on networks you trust.

--- a/ROBUSTNESS.md
+++ b/ROBUSTNESS.md
@@ -16,7 +16,10 @@ The suites cover peer registry retention/expiry, command correlation, request de
 cancel/completed/failed event separation, truncated and checksum-mismatched uploads,
 atomic equal-name commits, traversal rejection, progress backpressure, TLS pinning,
 HTTP `/register` fallback, and a session whose activity is older than five minutes while
-an upload is still active.
+an upload is still active. Incoming-PIN coverage includes secure startup,
+atomic persistence and rollback, exact `401`/`429` behavior, bounded per-IP
+failure state, text/file authorization before events, live PIN changes and an
+already authorized upload continuing after a change.
 
 ## Manual interoperability matrix
 
@@ -54,6 +57,23 @@ non-guest LAN. Confirm TCP and UDP 53317 are allowed.
    TCP/UDP 53317 listener or helper process.
 10. Test aliases, filenames and text containing `<b>`, quotes, `$()`, newlines and emoji.
     They must render literally and must not execute commands or markup.
+11. Enable Nearby incoming PIN `123456`. From official LocalSend, verify missing
+    and incorrect PINs do not surface a request, while the correct PIN reaches
+    the normal Accept/Decline flow for both text and files.
+12. Repeat with incoming PIN `Abc-_.~09`, then change it while discovery remains
+    active. The old value must fail, the new value must work and the receiver
+    must keep the same listening port.
+13. Begin and accept a file transfer, change the incoming PIN while it is in
+    progress and confirm that the transfer completes byte-for-byte.
+14. Restart Nearby and confirm the saved PIN is required on the first request.
+    Disable it and confirm a subsequent request no longer prompts for a PIN.
+15. Configure official LocalSend receiver PINs containing a space, Unicode and
+    each of `+`, `&`, `#` and `%`; verify Nearby can send text and files using
+    each exact value.
+
+Before releasing v1.1.0, record the exact Android and iOS LocalSend versions
+used for steps 11–15 here. These real-device checks are not considered complete
+until those versions and results are written down.
 
 The protocol's current main branch identifies itself as v2.2. Nearby remains wire-compatible
 with v2.1 and also returns v2.2's `422` for a declared SHA-256 mismatch. Discovery fingerprints

--- a/Service.qml
+++ b/Service.qml
@@ -209,8 +209,8 @@ Item {
   function chooseDevice(index) { if (index >= 0 && index < devices.length) { selectedDevice = devices[index]; viewState = "target"; cursorRequested(0) } }
   function clearTarget() { viewState = "nearby"; selectedDevice = null; cursorRequested(0) }
   function openIncomingPinSettings() { if(!backendReady)return; incomingPinError=""; viewState="incoming_pin_settings"; cursorRequested(0) }
-  function beginIncomingPinEdit() { if(incomingPinUpdating)return; incomingPinError=""; viewState="incoming_pin_edit"; incomingPinCleared(); incomingPinFocusRequested() }
-  function requestDisableIncomingPin() { if(incomingPinUpdating||!incomingPinEnabled)return; incomingPinError=""; viewState="incoming_pin_disable"; cursorRequested(0) }
+  function beginIncomingPinEdit() { if(incomingPinUpdating||!backendReady)return; incomingPinError=""; viewState="incoming_pin_edit"; incomingPinCleared(); incomingPinFocusRequested() }
+  function requestDisableIncomingPin() { if(incomingPinUpdating||!backendReady||!incomingPinEnabled)return; incomingPinError=""; viewState="incoming_pin_disable"; cursorRequested(0) }
   function cancelIncomingPinSettings() {
     if(incomingPinUpdating)return
     incomingPinError=""; incomingPinCleared()
@@ -218,14 +218,14 @@ Item {
     else{viewState="nearby";cursorRequested(0);focusRestoreRequested()}
   }
   function submitIncomingPin(pin) {
-    if(incomingPinUpdating)return
+    if(incomingPinUpdating||!backendReady)return
     var entered=String(pin || "")
     if(!/^[A-Za-z0-9._~-]{1,64}$/.test(entered)){incomingPinError="Use 1–64 letters, numbers, dot, underscore, tilde or hyphen";incomingPinFocusRequested();return}
     incomingPinUpdating=true; pendingIncomingPinEnabled=true; incomingPinError=""
     send({command:"set_incoming_pin",pin:entered})
   }
   function confirmDisableIncomingPin() {
-    if(incomingPinUpdating||!incomingPinEnabled)return
+    if(incomingPinUpdating||!backendReady||!incomingPinEnabled)return
     incomingPinUpdating=true; pendingIncomingPinEnabled=false; incomingPinError=""
     send({command:"disable_incoming_pin"})
   }
@@ -327,7 +327,8 @@ Item {
     } else {
       errorText=code===0 ? "Receiver stopped" : "Receiver unavailable"
       statusText=errorText
-      if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; errorText="Nearby backend stopped during transfer"; statusText=errorText }
+      if (viewState.indexOf("incoming_pin_")===0) { viewState="error"; errorText="Nearby backend stopped while updating receiver security"; statusText=errorText }
+      else if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; errorText="Nearby backend stopped during transfer"; statusText=errorText }
     }
     if (backendStartupFailureCode !== "receiver_security_settings_invalid" && backendRestart.attempts < 4) { backendRestart.attempts++; backendRestart.interval=Math.min(30000,1000*Math.pow(2,backendRestart.attempts-1)); backendRestart.restart() }
   }

--- a/Service.qml
+++ b/Service.qml
@@ -69,6 +69,10 @@ Item {
   property string outgoingTransferId: ""
   property var pendingOutgoing: null
   property string pinError: ""
+  property bool incomingPinEnabled: false
+  property bool incomingPinUpdating: false
+  property var pendingIncomingPinEnabled: null
+  property string incomingPinError: ""
   property int transferSequence: 0
   property bool shutdownPending: false
   property bool backendAcceptedThisRun: false
@@ -88,6 +92,8 @@ Item {
   signal cursorRequested(int index)
   signal pinCleared()
   signal pinFocusRequested()
+  signal incomingPinCleared()
+  signal incomingPinFocusRequested()
   signal focusRestoreRequested()
 
   FileView {
@@ -202,6 +208,27 @@ Item {
   function stopDiscovery() { discoveryActive = false; send({command:"discovery_stop"}) }
   function chooseDevice(index) { if (index >= 0 && index < devices.length) { selectedDevice = devices[index]; viewState = "target"; cursorRequested(0) } }
   function clearTarget() { viewState = "nearby"; selectedDevice = null; cursorRequested(0) }
+  function openIncomingPinSettings() { if(!backendReady)return; incomingPinError=""; viewState="incoming_pin_settings"; cursorRequested(0) }
+  function beginIncomingPinEdit() { if(incomingPinUpdating)return; incomingPinError=""; viewState="incoming_pin_edit"; incomingPinCleared(); incomingPinFocusRequested() }
+  function requestDisableIncomingPin() { if(incomingPinUpdating||!incomingPinEnabled)return; incomingPinError=""; viewState="incoming_pin_disable"; cursorRequested(0) }
+  function cancelIncomingPinSettings() {
+    if(incomingPinUpdating)return
+    incomingPinError=""; incomingPinCleared()
+    if(viewState==="incoming_pin_edit"||viewState==="incoming_pin_disable"){viewState="incoming_pin_settings";cursorRequested(0)}
+    else{viewState="nearby";cursorRequested(0);focusRestoreRequested()}
+  }
+  function submitIncomingPin(pin) {
+    if(incomingPinUpdating)return
+    var entered=String(pin || "")
+    if(!/^[A-Za-z0-9._~-]{1,64}$/.test(entered)){incomingPinError="Use 1–64 letters, numbers, dot, underscore, tilde or hyphen";incomingPinFocusRequested();return}
+    incomingPinUpdating=true; pendingIncomingPinEnabled=true; incomingPinError=""
+    send({command:"set_incoming_pin",pin:entered})
+  }
+  function confirmDisableIncomingPin() {
+    if(incomingPinUpdating||!incomingPinEnabled)return
+    incomingPinUpdating=true; pendingIncomingPinEnabled=false; incomingPinError=""
+    send({command:"disable_incoming_pin"})
+  }
   function failWith(message) { viewState="error"; errorText=message; statusText=errorText }
   function cancelOutgoing() { send({command:"cancel_outgoing",transfer_id:outgoingTransferId}) }
   function noteTextCopied() { if (viewState !== "text") return; viewState="success"; statusText="Received" }
@@ -277,7 +304,7 @@ Item {
   function finishText() { incomingText=""; incomingTextPending=false; viewState="nearby"; cursorRequested(0); startDiscovery() }
   function finishTerminal() { viewState="nearby"; cursorRequested(0); startDiscovery() }
   function handleBackendExit(code) {
-    backendReady=false; discoveryActive=false; incomingQueue=[]; incomingTextPending=false; activeIncomingSession=""; clearPendingOutgoing()
+    backendReady=false; discoveryActive=false; incomingQueue=[]; incomingTextPending=false; activeIncomingSession=""; incomingPinUpdating=false; pendingIncomingPinEnabled=null; incomingPinError=""; incomingPinCleared(); clearPendingOutgoing()
     if (shutdownPending) { finishReceiverShutdown(); return }
     if (!receiverEnabled) { statusText="Turned off"; errorText=""; return }
     if (backendVersionMismatch) return
@@ -286,7 +313,9 @@ Item {
       // confirmed bind conflict as a structured event before it exits; all
       // other pre-ready failures remain generic. Both keep the existing
       // bounded retry schedule so a transient conflict can recover.
-      if (backendRestart.attempts < 4) {
+      if (backendStartupFailureCode === "receiver_security_settings_invalid") {
+        errorText = "Nearby security settings are invalid. Repair or remove ~/.local/state/omarchy-nearby/settings.json."
+      } else if (backendRestart.attempts < 4) {
         errorText = "Nearby receiver could not start. Retrying…"
       } else if (backendStartupFailureCode === "receiver_port_in_use") {
         var port = backendStartupFailurePort > 0 ? backendStartupFailurePort : 53317
@@ -300,7 +329,7 @@ Item {
       statusText=errorText
       if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; errorText="Nearby backend stopped during transfer"; statusText=errorText }
     }
-    if (backendRestart.attempts < 4) { backendRestart.attempts++; backendRestart.interval=Math.min(30000,1000*Math.pow(2,backendRestart.attempts-1)); backendRestart.restart() }
+    if (backendStartupFailureCode !== "receiver_security_settings_invalid" && backendRestart.attempts < 4) { backendRestart.attempts++; backendRestart.interval=Math.min(30000,1000*Math.pow(2,backendRestart.attempts-1)); backendRestart.restart() }
   }
   function handleEvent(event) {
     if (!event || !event.event) return
@@ -320,11 +349,19 @@ Item {
       }
       backendAcceptedThisRun=true; backendReady=true; backendVersionMismatch=false; backendRestart.attempts=0; statusText="Ready to receive"; errorText=""; if(anyViewOpen&&viewState==="nearby")startDiscovery()
     }
+    else if (event.event === "incoming_pin_state") {
+      incomingPinEnabled=event.enabled===true
+      if(pendingIncomingPinEnabled!==null){var enabled=pendingIncomingPinEnabled===true;pendingIncomingPinEnabled=null;incomingPinUpdating=false;incomingPinError="";incomingPinCleared();viewState="incoming_pin_settings";statusText=enabled?"Incoming PIN enabled":"Incoming PIN disabled";cursorRequested(0);focusRestoreRequested()}
+    }
+    else if (event.event === "incoming_pin_update_failed") {
+      pendingIncomingPinEnabled=null;incomingPinUpdating=false;incomingPinError=String(event.message||"Unable to update incoming PIN");incomingPinCleared();if(viewState==="incoming_pin_edit")incomingPinFocusRequested()
+    }
     else if (event.event === "peer_snapshot") { devices=Model.snapshotDevices(event.devices); statusText=devices.length ? "Ready" : "Looking nearby…" }
     else if (event.event === "device") { devices=Model.upsertDevice(devices,event.device); statusText=devices.length ? "Ready" : "Looking nearby…" }
     else if (event.event === "discovery_started") discoveryActive=true
     else if (event.event === "discovery_stopped") discoveryActive=false
     else if (event.event === "incoming_request") {
+      if(viewState.indexOf("incoming_pin_")===0){incomingPinError="";incomingPinCleared()}
       incomingQueue=Model.enqueueIncoming(incomingQueue,event); if(!incomingTextPending)incomingText=""; if (viewState!=="sending" && viewState!=="receiving" && viewState!=="pin") { viewState="incoming"; cursorRequested(1) }
       Quickshell.execDetached(["notify-send","-a","Nearby","Incoming transfer",String(event.sender)+" wants to send "+Model.incomingSummary(event.files)])
     }

--- a/Service.qml
+++ b/Service.qml
@@ -314,7 +314,7 @@ Item {
       // other pre-ready failures remain generic. Both keep the existing
       // bounded retry schedule so a transient conflict can recover.
       if (backendStartupFailureCode === "receiver_security_settings_invalid") {
-        errorText = "Nearby security settings are invalid. Repair or remove ~/.local/state/omarchy-nearby/settings.json."
+        errorText = "Nearby security settings are invalid. Repair or remove Nearby's settings.json in your XDG state directory."
       } else if (backendRestart.attempts < 4) {
         errorText = "Nearby receiver could not start. Retrying…"
       } else if (backendStartupFailureCode === "receiver_port_in_use") {

--- a/Service.qml
+++ b/Service.qml
@@ -351,7 +351,7 @@ Item {
     }
     else if (event.event === "incoming_pin_state") {
       incomingPinEnabled=event.enabled===true
-      if(pendingIncomingPinEnabled!==null){var enabled=pendingIncomingPinEnabled===true;pendingIncomingPinEnabled=null;incomingPinUpdating=false;incomingPinError="";incomingPinCleared();viewState="incoming_pin_settings";statusText=enabled?"Incoming PIN enabled":"Incoming PIN disabled";cursorRequested(0);focusRestoreRequested()}
+      if(pendingIncomingPinEnabled!==null){var enabled=pendingIncomingPinEnabled===true;var settingsStillVisible=viewState.indexOf("incoming_pin_")===0;pendingIncomingPinEnabled=null;incomingPinUpdating=false;incomingPinError="";incomingPinCleared();if(settingsStillVisible){viewState="incoming_pin_settings";statusText=enabled?"Incoming PIN enabled":"Incoming PIN disabled";cursorRequested(0);focusRestoreRequested()}}
     }
     else if (event.event === "incoming_pin_update_failed") {
       pendingIncomingPinEnabled=null;incomingPinUpdating=false;incomingPinError=String(event.message||"Unable to update incoming PIN");incomingPinCleared();if(viewState==="incoming_pin_edit")incomingPinFocusRequested()
@@ -366,6 +366,7 @@ Item {
       Quickshell.execDetached(["notify-send","-a","Nearby","Incoming transfer",String(event.sender)+" wants to send "+Model.incomingSummary(event.files)])
     }
     else if (event.event === "incoming_text") {
+      if(viewState.indexOf("incoming_pin_")===0){incomingPinError="";incomingPinCleared()}
       incomingText=String(event.text || ""); transferPeer=String(event.sender || ""); incomingTextPending=pendingOutgoing!==null; if (!pendingOutgoing) { viewState="text"; stopDiscovery() }
       Quickshell.execDetached(["notify-send","-a","Nearby","Text received","From "+String(event.sender || "")])
     }

--- a/VENDORED_LOCALSEND_RS.md
+++ b/VENDORED_LOCALSEND_RS.md
@@ -33,17 +33,22 @@ moved the tree from `oma.nearby/backend/vendor/localsend-rs` to its current path
 Git records every vendor file in that commit as a 100% content-preserving rename,
 so it is not a local `localsend-rs` patch.
 
-After that relocation, Nearby's history records four content-changing vendor
-commits. Their cumulative diff is 298 insertions and 44 deletions across five
+After that relocation, Nearby's history records eight content-changing vendor
+commits. Their cumulative diff is 621 insertions and 79 deletions across ten
 files:
 
 | File | Insertions | Deletions |
 | --- | ---: | ---: |
-| `src/client/client.rs` | 50 | 1 |
+| `Cargo.lock` | 3 | 2 |
+| `Cargo.toml` | 1 | 0 |
+| `src/client/client.rs` | 81 | 11 |
 | `src/client/mod.rs` | 1 | 1 |
 | `src/discovery/http.rs` | 142 | 33 |
 | `src/discovery/multicast.rs` | 29 | 8 |
-| `tests/interop_upload.rs` | 76 | 1 |
+| `src/server/pin.rs` | 65 | 22 |
+| `src/server/server.rs` | 16 | 0 |
+| `tests/conformance_pin.rs` | 146 | 1 |
+| `tests/interop_upload.rs` | 137 | 1 |
 
 ## Local modification policy
 
@@ -160,6 +165,38 @@ existing streaming file-upload path.
 The integration test prepares a normal upload session, uploads an in-memory
 payload without a source file, and verifies the exact received bytes, completed
 session, and final progress count.
+
+### 5. Match official LocalSend receiver PIN enforcement and allow live changes
+
+- Nearby commits: `3b842ca` and `e51e10d`
+- Files: `Cargo.toml`, `Cargo.lock`, `src/server/pin.rs`,
+  `src/server/server.rs`, and `tests/conformance_pin.rs`
+
+The imported PIN gate counted a missing PIN as a failed attempt, kept an
+unbounded IP map and applied a five-minute cooldown. LocalSend 1.18.1 instead
+counts only supplied incorrect values, blocks after three failures without a
+timer and bounds failure state to an LRU cache of 200 IPs. Nearby now follows
+those semantics.
+
+`PinGate::set_pin(...)` and `LocalSendServer::set_pin(...)` expose the existing
+authentication state to Nearby's long-lived helper. Changing or disabling the
+credential clears stale failure state and affects only future prepare-upload
+checks; it does not restart the listener or invalidate an authorized session.
+Conformance tests cover status codes, event suppression, counter reset and live
+changes, while the upload integration test proves an authorized transfer
+survives a credential change.
+
+### 6. Encode outgoing PIN query values
+
+- Nearby commit: `74bd876`
+- Primary file: `src/client/client.rs`
+- Regression test: `prepare_upload_url_round_trips_reserved_and_unicode_pin_characters`
+
+The imported client interpolated a PIN directly into the prepare-upload URL.
+Reserved query characters could therefore be parsed as delimiters or fragments
+instead of arriving as part of the PIN. Nearby now builds the URL with
+`reqwest::Url` and appends `pin` through its query serializer. Tests cover
+spaces, Unicode, `+`, `&`, `#` and `%` round-tripping unchanged.
 
 ## Nearby behavior outside the vendor
 

--- a/VENDORED_LOCALSEND_RS.md
+++ b/VENDORED_LOCALSEND_RS.md
@@ -168,7 +168,7 @@ session, and final progress count.
 
 ### 5. Match official LocalSend receiver PIN enforcement and allow live changes
 
-- Nearby commits: `3b842ca` and `e51e10d`
+- Nearby commits: `3b842ca`, `e51e10d` and `f08c52a`
 - Files: `Cargo.toml`, `Cargo.lock`, `src/server/pin.rs`,
   `src/server/server.rs`, and `tests/conformance_pin.rs`
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "omarchy-nearby-helper"
-version = "1.0.7"
+version = "1.1.0-dev"
 dependencies = [
  "anyhow",
  "localsend-rs",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +630,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -877,7 +900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -994,6 +1017,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "if-addrs",
+ "lru",
  "mime_guess",
  "parking_lot",
  "rcgen",
@@ -1028,6 +1052,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru-slab"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omarchy-nearby-helper"
-version = "1.0.7"
+version = "1.1.0-dev"
 edition = "2024"
 license = "MIT"
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -21,6 +21,8 @@ use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::{mpsc, oneshot};
 
+mod settings;
+
 const PEER_TTL: Duration = Duration::from_secs(90);
 const MULTICAST_GRACE: Duration = Duration::from_secs(1);
 const CACHED_PROBE_CONCURRENCY: usize = 5;
@@ -88,6 +90,10 @@ enum Command {
     CancelOutgoing {
         transfer_id: String,
     },
+    SetIncomingPin {
+        pin: String,
+    },
+    DisableIncomingPin,
     Shutdown,
 }
 
@@ -724,10 +730,7 @@ async fn cleanup_stale_partial_files(directory: &Path, minimum_age: Duration) ->
 }
 
 fn load_identity(home: &Path) -> Result<TlsCertificate> {
-    let state_dir = std::env::var("XDG_STATE_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| home.join(".local/state"))
-        .join("omarchy-nearby");
+    let state_dir = settings::state_dir(home);
     std::fs::create_dir_all(&state_dir)?;
     let path = state_dir.join("identity.json");
     if let Ok(data) = std::fs::read(&path) {
@@ -755,9 +758,44 @@ fn load_identity(home: &Path) -> Result<TlsCertificate> {
     Ok(cert)
 }
 
+async fn update_incoming_pin(
+    server: &mut LocalSendServer,
+    settings_path: &Path,
+    current: &mut settings::Settings,
+    pin: Option<String>,
+) -> Result<()> {
+    let next = settings::updated(current, pin)?;
+    let previous_pin = current.incoming_pin.clone();
+    server.set_pin(next.incoming_pin.clone()).await?;
+    if let Err(error) = settings::save(settings_path, &next) {
+        server
+            .set_pin(previous_pin)
+            .await
+            .context("could not restore previous live PIN state")?;
+        return Err(error);
+    }
+    *current = next;
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let home = PathBuf::from(std::env::var("HOME").context("HOME is not set")?);
+    let state_dir = settings::state_dir(&home);
+    let settings_path = state_dir.join("settings.json");
+    let mut receiver_settings = match settings::ensure_private_state_dir(&state_dir)
+        .and_then(|_| settings::load(&settings_path))
+    {
+        Ok(settings) => settings,
+        Err(error) => {
+            emit(json!({
+                "event": "startup_failed",
+                "code": "receiver_security_settings_invalid",
+            }));
+            let _ = std::io::stdout().flush();
+            return Err(error.context("receiver security settings unavailable"));
+        }
+    };
     let download_dir = xdg_download_dir(&home);
     tokio::fs::create_dir_all(&download_dir)
         .await
@@ -775,16 +813,18 @@ async fn main() -> Result<()> {
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "Omarchy".into());
     let certificate = load_identity(&home).context("TLS identity unavailable")?;
-    let started = LocalSendServer::builder()
+    let mut builder = LocalSendServer::builder()
         .alias(alias)
         .port(NEARBY_PORT)
         .save_dir(&canonical_download)
         .protocol(Protocol::Https)
         .tls_certificate(certificate.clone())
-        .auto_accept(false)
-        .build()
-        .await;
-    let (server, mut events) = match started {
+        .auto_accept(false);
+    if let Some(pin) = receiver_settings.incoming_pin.clone() {
+        builder = builder.pin(pin);
+    }
+    let started = builder.build().await;
+    let (mut server, mut events) = match started {
         Ok(started) => started,
         Err(error) => {
             let error = anyhow::Error::new(error);
@@ -819,6 +859,7 @@ async fn main() -> Result<()> {
     emit(
         json!({"event":"ready","helperVersion":env!("CARGO_PKG_VERSION"),"alias":identity.alias,"directory":canonical_download,"port":server.port(),"fingerprint":identity.fingerprint}),
     );
+    emit(json!({"event":"incoming_pin_state","enabled":receiver_settings.incoming_pin.is_some()}));
     let pending = Arc::new(Mutex::new(HashMap::<String, PendingRequest>::new()));
     let pending_events = pending.clone();
     let peer_events = peer_tx.clone();
@@ -949,6 +990,18 @@ async fn main() -> Result<()> {
                         });
                     }
                     Command::CancelOutgoing { transfer_id } => if outgoing.as_ref().is_some_and(|o|o.id==transfer_id) { if let Some(control)=outgoing.take(){let _=control.cancel.send(());} },
+                    Command::SetIncomingPin { pin } => {
+                        match update_incoming_pin(&mut server,&settings_path,&mut receiver_settings,Some(pin)).await {
+                            Ok(())=>emit(json!({"event":"incoming_pin_state","enabled":true})),
+                            Err(_)=>emit(json!({"event":"incoming_pin_update_failed","message":"Unable to update incoming PIN"})),
+                        }
+                    },
+                    Command::DisableIncomingPin => {
+                        match update_incoming_pin(&mut server,&settings_path,&mut receiver_settings,None).await {
+                            Ok(())=>emit(json!({"event":"incoming_pin_state","enabled":false})),
+                            Err(_)=>emit(json!({"event":"incoming_pin_update_failed","message":"Unable to update incoming PIN"})),
+                        }
+                    },
                     Command::Shutdown => break,
                 }
             }
@@ -1095,6 +1148,149 @@ mod tests {
             serde_json::from_str::<Command>(with_pin).unwrap(),
             Command::SendText { pin: Some(pin), .. } if pin == "123456"
         ));
+    }
+
+    #[test]
+    fn incoming_pin_commands_have_distinct_set_and_disable_operations() {
+        assert!(matches!(
+            serde_json::from_str::<Command>(
+                r#"{"command":"set_incoming_pin","pin":"Abc-123"}"#
+            )
+            .unwrap(),
+            Command::SetIncomingPin { pin } if pin == "Abc-123"
+        ));
+        assert!(matches!(
+            serde_json::from_str::<Command>(r#"{"command":"disable_incoming_pin"}"#).unwrap(),
+            Command::DisableIncomingPin
+        ));
+    }
+
+    #[tokio::test]
+    async fn incoming_pin_update_persists_and_changes_the_running_server() {
+        let directory = std::env::temp_dir().join(format!(
+            "omarchy-nearby-live-pin-test-{}-{}",
+            std::process::id(),
+            FileId::new().as_str()
+        ));
+        let save_directory = directory.join("downloads");
+        tokio::fs::create_dir_all(&save_directory).await.unwrap();
+        let settings_path = directory.join("state/settings.json");
+        let (mut server, _events) = LocalSendServer::builder()
+            .alias("Live PIN")
+            .port(0)
+            .save_dir(&save_directory)
+            .protocol(Protocol::Http)
+            .auto_accept(true)
+            .build()
+            .await
+            .unwrap();
+        let mut current = settings::Settings::default();
+        update_incoming_pin(
+            &mut server,
+            &settings_path,
+            &mut current,
+            Some("Safe-1".to_string()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            settings::load(&settings_path)
+                .unwrap()
+                .incoming_pin
+                .as_deref(),
+            Some("Safe-1")
+        );
+
+        let mut target = DeviceInfo::new("Live PIN".into(), server.port(), Protocol::Http);
+        target.ip = Some("127.0.0.1".into());
+        let client = LocalSendClient::new(DeviceInfo::new("Sender".into(), 53317, Protocol::Http));
+        assert!(matches!(
+            client.prepare_upload(&target, HashMap::new(), None).await,
+            Err(LocalSendError::InvalidPin)
+        ));
+        assert!(
+            client
+                .prepare_upload(&target, HashMap::new(), Some("Safe-1"))
+                .await
+                .is_ok()
+        );
+
+        update_incoming_pin(&mut server, &settings_path, &mut current, None)
+            .await
+            .unwrap();
+        assert!(
+            client
+                .prepare_upload(&target, HashMap::new(), None)
+                .await
+                .is_ok()
+        );
+        assert!(
+            settings::load(&settings_path)
+                .unwrap()
+                .incoming_pin
+                .is_none()
+        );
+
+        server.stop();
+        tokio::fs::remove_dir_all(directory).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn persistence_failure_restores_the_previous_live_pin() {
+        let directory = std::env::temp_dir().join(format!(
+            "omarchy-nearby-pin-rollback-test-{}-{}",
+            std::process::id(),
+            FileId::new().as_str()
+        ));
+        tokio::fs::create_dir_all(&directory).await.unwrap();
+        let blocker = directory.join("not-a-directory");
+        tokio::fs::write(&blocker, b"block").await.unwrap();
+        let impossible_path = blocker.join("settings.json");
+        let save_directory = directory.join("downloads");
+        tokio::fs::create_dir_all(&save_directory).await.unwrap();
+        let (mut server, _events) = LocalSendServer::builder()
+            .alias("Rollback PIN")
+            .port(0)
+            .save_dir(&save_directory)
+            .protocol(Protocol::Http)
+            .pin("Old-1")
+            .auto_accept(true)
+            .build()
+            .await
+            .unwrap();
+        let mut current =
+            settings::updated(&settings::Settings::default(), Some("Old-1".to_string())).unwrap();
+
+        assert!(
+            update_incoming_pin(
+                &mut server,
+                &impossible_path,
+                &mut current,
+                Some("New-1".to_string())
+            )
+            .await
+            .is_err()
+        );
+        assert_eq!(current.incoming_pin.as_deref(), Some("Old-1"));
+
+        let mut target = DeviceInfo::new("Rollback PIN".into(), server.port(), Protocol::Http);
+        target.ip = Some("127.0.0.1".into());
+        let client = LocalSendClient::new(DeviceInfo::new("Sender".into(), 53317, Protocol::Http));
+        assert!(
+            client
+                .prepare_upload(&target, HashMap::new(), Some("Old-1"))
+                .await
+                .is_ok()
+        );
+        assert!(matches!(
+            client
+                .prepare_upload(&target, HashMap::new(), Some("New-1"))
+                .await,
+            Err(LocalSendError::InvalidPin)
+        ));
+
+        server.stop();
+        tokio::fs::remove_dir_all(directory).await.unwrap();
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -27,6 +27,11 @@ const CACHED_PROBE_CONCURRENCY: usize = 5;
 const MAX_SUBNET_ADDRESSES: u32 = 1024;
 const STALE_PARTIAL_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 const NEARBY_PORT: u16 = 53317;
+const MAX_OUTGOING_PIN_BYTES: usize = 4096;
+
+fn valid_outgoing_pin(pin: Option<&str>) -> bool {
+    pin.is_none_or(|value| !value.is_empty() && value.len() <= MAX_OUTGOING_PIN_BYTES)
+}
 
 /// True when a failure was caused by the LocalSend port already being bound.
 ///
@@ -917,6 +922,7 @@ async fn main() -> Result<()> {
                     Command::Decline { request_id } => { let ok=pending.lock().unwrap().remove(&request_id).is_some_and(|req|req.decline()); emit(if ok {json!({"event":"incoming_declined","requestId":request_id})} else {json!({"event":"incoming_expired","requestId":request_id})}); },
                     Command::SendFiles { transfer_id,device,paths,pin } => {
                         if outgoing.is_some(){emit(json!({"event":"outgoing_failed","transferId":transfer_id,"message":"Another transfer is already active"}));continue;}
+                        if !valid_outgoing_pin(pin.as_deref()){emit(json!({"event":"outgoing_failed","transferId":transfer_id,"message":"Invalid receiver PIN"}));continue;}
                         let (tx,rx)=oneshot::channel(); outgoing=Some(OutgoingControl{id:transfer_id.clone(),cancel:tx});
                         let (identity,certificate,done)=(identity.clone(),certificate.clone(),out_done_tx.clone()); tokio::spawn(async move {
                             let event=match send_payload(transfer_id.clone(),identity,certificate,device,paths,None,pin,rx).await {
@@ -930,6 +936,7 @@ async fn main() -> Result<()> {
                     }
                     Command::SendText { transfer_id,device,text,pin } => {
                         if outgoing.is_some(){emit(json!({"event":"outgoing_failed","transferId":transfer_id,"message":"Another transfer is already active"}));continue;}
+                        if !valid_outgoing_pin(pin.as_deref()){emit(json!({"event":"outgoing_failed","transferId":transfer_id,"message":"Invalid receiver PIN"}));continue;}
                         let (tx,rx)=oneshot::channel(); outgoing=Some(OutgoingControl{id:transfer_id.clone(),cancel:tx});
                         let (identity,certificate,done)=(identity.clone(),certificate.clone(),out_done_tx.clone()); tokio::spawn(async move {
                             let event=match send_payload(transfer_id.clone(),identity,certificate,device,vec![],Some(text),pin,rx).await {
@@ -998,6 +1005,22 @@ mod tests {
         let denied = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
         let wrapped = anyhow::Error::new(denied).context("receiver could not start");
         assert_eq!(startup_failure_event(&wrapped), None);
+    }
+
+    #[test]
+    fn outgoing_pin_validation_accepts_general_text_with_a_defensive_byte_limit() {
+        assert!(valid_outgoing_pin(None));
+        assert!(valid_outgoing_pin(Some("a+b & # % contraseña")));
+        assert!(!valid_outgoing_pin(Some("")));
+        assert!(valid_outgoing_pin(Some(
+            &"x".repeat(MAX_OUTGOING_PIN_BYTES)
+        )));
+        assert!(!valid_outgoing_pin(Some(
+            &"x".repeat(MAX_OUTGOING_PIN_BYTES + 1)
+        )));
+        assert!(!valid_outgoing_pin(Some(
+            &"ñ".repeat(MAX_OUTGOING_PIN_BYTES / 2 + 1)
+        )));
     }
 
     #[test]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -7,7 +7,7 @@ use localsend_rs::discovery::{Discovery, HttpDiscovery, MulticastDiscovery};
 use localsend_rs::error::LocalSendError;
 use localsend_rs::protocol::types::FileMetadataDetails;
 use localsend_rs::protocol::{DeviceInfo, FileId, FileMetadata, Protocol};
-use localsend_rs::server::{PendingRequest, ServerEvent};
+use localsend_rs::server::{LocalSendServerBuilder, PendingRequest, ServerEvent};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -778,6 +778,16 @@ async fn update_incoming_pin(
     Ok(())
 }
 
+fn configure_receiver_pin(
+    builder: LocalSendServerBuilder,
+    receiver_settings: &settings::Settings,
+) -> LocalSendServerBuilder {
+    match receiver_settings.incoming_pin.as_deref() {
+        Some(pin) => builder.pin(pin.to_string()),
+        None => builder,
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let home = PathBuf::from(std::env::var("HOME").context("HOME is not set")?);
@@ -820,9 +830,7 @@ async fn main() -> Result<()> {
         .protocol(Protocol::Https)
         .tls_certificate(certificate.clone())
         .auto_accept(false);
-    if let Some(pin) = receiver_settings.incoming_pin.clone() {
-        builder = builder.pin(pin);
-    }
+    builder = configure_receiver_pin(builder, &receiver_settings);
     let started = builder.build().await;
     let (mut server, mut events) = match started {
         Ok(started) => started,
@@ -1229,6 +1237,53 @@ mod tests {
                 .unwrap()
                 .incoming_pin
                 .is_none()
+        );
+
+        server.stop();
+        tokio::fs::remove_dir_all(directory).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn persisted_pin_is_applied_when_the_receiver_is_built() {
+        let directory = std::env::temp_dir().join(format!(
+            "omarchy-nearby-startup-pin-test-{}-{}",
+            std::process::id(),
+            FileId::new().as_str()
+        ));
+        let save_directory = directory.join("downloads");
+        tokio::fs::create_dir_all(&save_directory).await.unwrap();
+        let settings_path = directory.join("state/settings.json");
+        let persisted = settings::updated(
+            &settings::Settings::default(),
+            Some("Startup-1".to_string()),
+        )
+        .unwrap();
+        settings::save(&settings_path, &persisted).unwrap();
+        let loaded = settings::load(&settings_path).unwrap();
+
+        let builder = LocalSendServer::builder()
+            .alias("Startup PIN")
+            .port(0)
+            .save_dir(&save_directory)
+            .protocol(Protocol::Http)
+            .auto_accept(true);
+        let (mut server, _events) = configure_receiver_pin(builder, &loaded)
+            .build()
+            .await
+            .unwrap();
+        let mut target = DeviceInfo::new("Startup PIN".into(), server.port(), Protocol::Http);
+        target.ip = Some("127.0.0.1".into());
+        let client = LocalSendClient::new(DeviceInfo::new("Sender".into(), 53317, Protocol::Http));
+
+        assert!(matches!(
+            client.prepare_upload(&target, HashMap::new(), None).await,
+            Err(LocalSendError::InvalidPin)
+        ));
+        assert!(
+            client
+                .prepare_upload(&target, HashMap::new(), Some("Startup-1"))
+                .await
+                .is_ok()
         );
 
         server.stop();

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -765,14 +765,15 @@ async fn update_incoming_pin(
     pin: Option<String>,
 ) -> Result<()> {
     let next = settings::updated(current, pin)?;
-    let previous_pin = current.incoming_pin.clone();
-    server.set_pin(next.incoming_pin.clone()).await?;
-    if let Err(error) = settings::save(settings_path, &next) {
-        server
-            .set_pin(previous_pin)
-            .await
-            .context("could not restore previous live PIN state")?;
-        return Err(error);
+    let previous = current.clone();
+    settings::save(settings_path, &next)?;
+    if let Err(live_error) = server.set_pin(next.incoming_pin.clone()).await {
+        if let Err(rollback_error) = settings::save(settings_path, &previous) {
+            return Err(anyhow!(
+                "could not apply live PIN state ({live_error}); could not restore persisted PIN state: {rollback_error:#}"
+            ));
+        }
+        return Err(live_error.into());
     }
     *current = next;
     Ok(())
@@ -1291,9 +1292,70 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn persistence_failure_restores_the_previous_live_pin() {
+    async fn persistence_failure_preserves_the_previous_lockout() {
         let directory = std::env::temp_dir().join(format!(
             "omarchy-nearby-pin-rollback-test-{}-{}",
+            std::process::id(),
+            FileId::new().as_str()
+        ));
+        tokio::fs::create_dir_all(&directory).await.unwrap();
+        let blocker = directory.join("not-a-directory");
+        tokio::fs::write(&blocker, b"block").await.unwrap();
+        let impossible_path = blocker.join("settings.json");
+        let save_directory = directory.join("downloads");
+        tokio::fs::create_dir_all(&save_directory).await.unwrap();
+        let (mut server, _events) = LocalSendServer::builder()
+            .alias("Rollback PIN")
+            .port(0)
+            .save_dir(&save_directory)
+            .protocol(Protocol::Http)
+            .pin("Old-1")
+            .auto_accept(true)
+            .build()
+            .await
+            .unwrap();
+        let mut current =
+            settings::updated(&settings::Settings::default(), Some("Old-1".to_string())).unwrap();
+
+        let mut target = DeviceInfo::new("Rollback PIN".into(), server.port(), Protocol::Http);
+        target.ip = Some("127.0.0.1".into());
+        let client = LocalSendClient::new(DeviceInfo::new("Sender".into(), 53317, Protocol::Http));
+        for _ in 0..3 {
+            assert!(matches!(
+                client
+                    .prepare_upload(&target, HashMap::new(), Some("wrong"))
+                    .await,
+                Err(LocalSendError::InvalidPin)
+            ));
+        }
+        assert!(matches!(
+            client
+                .prepare_upload(&target, HashMap::new(), Some("Old-1"))
+                .await,
+            Err(LocalSendError::RateLimited)
+        ));
+
+        assert!(
+            update_incoming_pin(&mut server, &impossible_path, &mut current, None)
+                .await
+                .is_err()
+        );
+        assert_eq!(current.incoming_pin.as_deref(), Some("Old-1"));
+        assert!(matches!(
+            client
+                .prepare_upload(&target, HashMap::new(), Some("Old-1"))
+                .await,
+            Err(LocalSendError::RateLimited)
+        ));
+
+        server.stop();
+        tokio::fs::remove_dir_all(directory).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn persistence_failure_preserves_the_previous_live_pin() {
+        let directory = std::env::temp_dir().join(format!(
+            "omarchy-nearby-pin-credential-test-{}-{}",
             std::process::id(),
             FileId::new().as_str()
         ));

--- a/backend/src/settings.rs
+++ b/backend/src/settings.rs
@@ -1,0 +1,215 @@
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const SETTINGS_VERSION: u32 = 1;
+const MAX_INCOMING_PIN_LENGTH: usize = 64;
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Settings {
+    version: u32,
+    #[serde(default)]
+    pub incoming_pin: Option<String>,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            version: SETTINGS_VERSION,
+            incoming_pin: None,
+        }
+    }
+}
+
+pub fn valid_incoming_pin(pin: &str) -> bool {
+    !pin.is_empty()
+        && pin.len() <= MAX_INCOMING_PIN_LENGTH
+        && pin
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'~' | b'-'))
+}
+
+fn validate(settings: &Settings) -> Result<()> {
+    if settings.version != SETTINGS_VERSION {
+        return Err(anyhow!("unsupported security settings version"));
+    }
+    if settings
+        .incoming_pin
+        .as_deref()
+        .is_some_and(|pin| !valid_incoming_pin(pin))
+    {
+        return Err(anyhow!("invalid incoming PIN configuration"));
+    }
+    Ok(())
+}
+
+pub fn state_dir(home: &Path) -> PathBuf {
+    std::env::var("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| home.join(".local/state"))
+        .join("omarchy-nearby")
+}
+
+pub fn ensure_private_state_dir(path: &Path) -> Result<()> {
+    fs::create_dir_all(path).context("could not create Nearby state directory")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .context("could not protect Nearby state directory")?;
+    }
+    Ok(())
+}
+
+pub fn load(path: &Path) -> Result<Settings> {
+    let data = match fs::read(path) {
+        Ok(data) => data,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Settings::default()),
+        Err(error) => return Err(error).context("could not read security settings"),
+    };
+    let settings: Settings =
+        serde_json::from_slice(&data).context("could not parse security settings")?;
+    validate(&settings)?;
+    Ok(settings)
+}
+
+pub fn save(path: &Path, settings: &Settings) -> Result<()> {
+    validate(settings)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("security settings path has no parent"))?;
+    ensure_private_state_dir(parent)?;
+    let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let temporary = parent.join(format!(
+        ".settings.json.tmp-{}-{sequence}",
+        std::process::id()
+    ));
+    let data = serde_json::to_vec_pretty(settings).context("could not serialize settings")?;
+
+    let result = (|| -> Result<()> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&temporary)
+            .context("could not create temporary security settings")?;
+        file.write_all(&data)
+            .context("could not write security settings")?;
+        file.write_all(b"\n")
+            .context("could not finish security settings")?;
+        file.sync_all()
+            .context("could not flush security settings")?;
+        drop(file);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&temporary, fs::Permissions::from_mode(0o600))
+                .context("could not protect security settings")?;
+        }
+        fs::rename(&temporary, path).context("could not replace security settings")?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+pub fn updated(current: &Settings, incoming_pin: Option<String>) -> Result<Settings> {
+    let next = Settings {
+        version: current.version,
+        incoming_pin,
+    };
+    validate(&next)?;
+    Ok(next)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_directory(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "omarchy-nearby-settings-{name}-{}-{}",
+            std::process::id(),
+            TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[test]
+    fn incoming_pin_profile_is_exact() {
+        for pin in ["1", "123456", "Abc-_.~09", &"x".repeat(64)] {
+            assert!(valid_incoming_pin(pin), "expected valid PIN: {pin}");
+        }
+        for pin in [
+            "",
+            "with space",
+            "a+b",
+            "a&b",
+            "contraseña",
+            &"x".repeat(65),
+        ] {
+            assert!(!valid_incoming_pin(pin), "expected invalid PIN: {pin}");
+        }
+    }
+
+    #[test]
+    fn missing_settings_are_disabled_and_valid_settings_round_trip() {
+        let directory = test_directory("round-trip");
+        let path = directory.join("settings.json");
+        assert_eq!(load(&path).unwrap(), Settings::default());
+
+        let settings = updated(&Settings::default(), Some("Abc-123".to_string())).unwrap();
+        save(&path, &settings).unwrap();
+        assert_eq!(load(&path).unwrap(), settings);
+        assert_eq!(fs::read_dir(&directory).unwrap().count(), 1);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&directory).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn malformed_unsupported_and_invalid_settings_fail_closed() {
+        let directory = test_directory("invalid");
+        fs::create_dir_all(&directory).unwrap();
+        let path = directory.join("settings.json");
+
+        for data in [
+            b"not json".as_slice(),
+            br#"{"version":2,"incomingPin":null}"#,
+            br#"{"version":1,"incomingPin":"a+b"}"#,
+        ] {
+            fs::write(&path, data).unwrap();
+            assert!(load(&path).is_err());
+        }
+
+        fs::write(
+            &path,
+            br#"{"version":1,"incomingPin":"Safe-1","futureField":true}"#,
+        )
+        .unwrap();
+        assert_eq!(load(&path).unwrap().incoming_pin.as_deref(), Some("Safe-1"));
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/backend/vendor/localsend-rs/Cargo.lock
+++ b/backend/vendor/localsend-rs/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "indicatif",
  "inquire",
  "itertools",
+ "lru",
  "mime_guess",
  "parking_lot",
  "ratatui",
@@ -1606,9 +1607,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown",
 ]

--- a/backend/vendor/localsend-rs/Cargo.toml
+++ b/backend/vendor/localsend-rs/Cargo.toml
@@ -88,6 +88,7 @@ strum = { version = "0.27", features = ["derive"], optional = true }
 itertools = { version = "0.14", optional = true }
 chrono = { version = "0.4.43", features = ["serde"] }
 parking_lot = "0.12"
+lru = "0.16"
 
 [dev-dependencies]
 tempfile = "3"

--- a/backend/vendor/localsend-rs/src/client/client.rs
+++ b/backend/vendor/localsend-rs/src/client/client.rs
@@ -15,6 +15,19 @@ use tokio_util::io::ReaderStream;
 
 pub type ProgressCallback = Box<dyn Fn(u64, u64, f64) + Send + Sync>;
 
+fn prepare_upload_url(target: &DeviceInfo, ip: &str, pin: Option<&str>) -> Result<reqwest::Url> {
+    let base = format!(
+        "{}://{}:{}/api/localsend/v2/prepare-upload",
+        target.protocol, ip, target.port
+    );
+    let mut url = reqwest::Url::parse(&base)
+        .map_err(|error| LocalSendError::network(format!("Invalid target URL: {error}")))?;
+    if let Some(pin) = pin {
+        url.query_pairs_mut().append_pair("pin", pin);
+    }
+    Ok(url)
+}
+
 #[cfg(feature = "https")]
 fn reqwest_identity(identity: &TlsCertificate) -> Result<reqwest::Identity> {
     let pem = format!("{}\n{}", identity.cert_pem, identity.key_pem);
@@ -159,21 +172,14 @@ impl LocalSendClient {
             .ip
             .as_ref()
             .ok_or_else(|| LocalSendError::network("Target IP not provided"))?;
-        let mut url = format!(
-            "{}://{}:{}/api/localsend/v2/prepare-upload",
-            target.protocol, ip, target.port
-        );
-
-        if let Some(pin_value) = pin {
-            url = format!("{}?pin={}", url, pin_value);
-        }
+        let url = prepare_upload_url(target, ip, pin)?;
 
         let request = PrepareUploadRequest {
             info: self.device.clone(),
             files,
         };
 
-        let response = self.client.post(&url).json(&request).send().await?;
+        let response = self.client.post(url).json(&request).send().await?;
 
         let status = response.status();
         match status {
@@ -457,7 +463,7 @@ impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
 
 #[cfg(test)]
 mod tests {
-    use super::LocalSendClient;
+    use super::{LocalSendClient, prepare_upload_url};
     use crate::client::TlsTrustPolicy;
     use crate::protocol::{DeviceInfo, Protocol};
 
@@ -473,6 +479,21 @@ mod tests {
         assert!(!policy.allows(""));
         // Client must construct without panicking and remain usable for the device payload.
         assert_eq!(client.device.alias, "alias");
+    }
+
+    #[test]
+    fn prepare_upload_url_round_trips_reserved_and_unicode_pin_characters() {
+        let mut target = DeviceInfo::new("receiver".to_string(), 53317, Protocol::Http);
+        target.ip = Some("192.0.2.2".to_string());
+
+        for pin in ["with space", "a+b", "a&b", "a#b", "a%b", "contraseña"] {
+            let url =
+                prepare_upload_url(&target, target.ip.as_deref().unwrap(), Some(pin)).unwrap();
+            let received = url
+                .query_pairs()
+                .find_map(|(key, value)| (key == "pin").then(|| value.into_owned()));
+            assert_eq!(received.as_deref(), Some(pin));
+        }
     }
 
     #[cfg(not(feature = "https"))]

--- a/backend/vendor/localsend-rs/src/server/pin.rs
+++ b/backend/vendor/localsend-rs/src/server/pin.rs
@@ -1,12 +1,11 @@
-//! Receiver-side PIN enforcement: 401 on mismatch, 3 failures -> 429 + 5 min cooldown
-//! (matches official LocalSend app behavior).
+//! Receiver-side PIN enforcement matching the official LocalSend server.
 
-use std::collections::HashMap;
+use lru::LruCache;
 use std::net::IpAddr;
-use std::time::{Duration, Instant};
+use std::num::NonZeroUsize;
 
 pub const MAX_FAILURES: u32 = 3;
-pub const LOCKOUT: Duration = Duration::from_secs(5 * 60);
+const FAILURE_CACHE_CAPACITY: usize = 200;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum PinVerdict {
@@ -18,14 +17,14 @@ pub enum PinVerdict {
 #[derive(Debug)]
 pub struct PinGate {
     pin: Option<String>,
-    failures: HashMap<IpAddr, (u32, Instant)>, // (count, last_failure)
+    failures: LruCache<IpAddr, u32>,
 }
 
 impl PinGate {
     pub fn new(pin: Option<String>) -> Self {
         Self {
             pin,
-            failures: HashMap::new(),
+            failures: LruCache::new(NonZeroUsize::new(FAILURE_CACHE_CAPACITY).unwrap()),
         }
     }
 
@@ -34,23 +33,21 @@ impl PinGate {
             return PinVerdict::Ok;
         };
 
-        if let Some((count, at)) = self.failures.get(&peer)
-            && *count >= MAX_FAILURES
-        {
-            if at.elapsed() < LOCKOUT {
-                return PinVerdict::LockedOut;
-            }
-            self.failures.remove(&peer);
+        let count = self.failures.get(&peer).copied().unwrap_or(0);
+        if count >= MAX_FAILURES {
+            return PinVerdict::LockedOut;
         }
 
-        if provided.is_some_and(|p| constant_time_eq(p.as_bytes(), expected.as_bytes())) {
-            self.failures.remove(&peer);
-            PinVerdict::Ok
-        } else {
-            let entry = self.failures.entry(peer).or_insert((0, Instant::now()));
-            entry.0 += 1;
-            entry.1 = Instant::now();
-            PinVerdict::Unauthorized
+        match provided {
+            Some(pin) if constant_time_eq(pin.as_bytes(), expected.as_bytes()) => {
+                self.failures.pop(&peer);
+                PinVerdict::Ok
+            }
+            Some(_) => {
+                self.failures.put(peer, count + 1);
+                PinVerdict::Unauthorized
+            }
+            None => PinVerdict::Unauthorized,
         }
     }
 }
@@ -87,6 +84,15 @@ mod tests {
     }
 
     #[test]
+    fn missing_pin_does_not_increase_failure_count() {
+        let mut g = PinGate::new(Some("123456".to_string()));
+        for _ in 0..10 {
+            assert_eq!(g.check(None, PEER), PinVerdict::Unauthorized);
+        }
+        assert_eq!(g.check(Some("123456"), PEER), PinVerdict::Ok);
+    }
+
+    #[test]
     fn three_failures_lock_out_that_peer_only() {
         let mut g = PinGate::new(Some("123456".to_string()));
         for _ in 0..3 {
@@ -108,5 +114,19 @@ mod tests {
         g.check(Some("bad"), PEER);
         g.check(Some("bad"), PEER);
         assert_eq!(g.check(Some("123456"), PEER), PinVerdict::Ok);
+    }
+
+    #[test]
+    fn failure_cache_is_bounded_and_evicts_least_recently_used_ip() {
+        let mut g = PinGate::new(Some("123456".to_string()));
+        let first = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+        for host in 1..=201u16 {
+            let peer = IpAddr::V4(Ipv4Addr::new(10, 0, (host / 256) as u8, host as u8));
+            assert_eq!(g.check(Some("bad"), peer), PinVerdict::Unauthorized);
+        }
+
+        assert_eq!(g.failures.len(), FAILURE_CACHE_CAPACITY);
+        assert!(g.failures.peek(&first).is_none());
     }
 }

--- a/backend/vendor/localsend-rs/src/server/pin.rs
+++ b/backend/vendor/localsend-rs/src/server/pin.rs
@@ -50,6 +50,11 @@ impl PinGate {
             None => PinVerdict::Unauthorized,
         }
     }
+
+    pub fn set_pin(&mut self, pin: Option<String>) {
+        self.pin = pin;
+        self.failures.clear();
+    }
 }
 
 /// Length-leaking-free comparison without extra deps.
@@ -128,5 +133,23 @@ mod tests {
 
         assert_eq!(g.failures.len(), FAILURE_CACHE_CAPACITY);
         assert!(g.failures.peek(&first).is_none());
+    }
+
+    #[test]
+    fn changing_or_disabling_pin_clears_failure_state() {
+        let mut g = PinGate::new(Some("old".to_string()));
+        for _ in 0..MAX_FAILURES {
+            assert_eq!(g.check(Some("bad"), PEER), PinVerdict::Unauthorized);
+        }
+        assert_eq!(g.check(Some("old"), PEER), PinVerdict::LockedOut);
+
+        g.set_pin(Some("new".to_string()));
+        assert_eq!(g.check(Some("old"), PEER), PinVerdict::Unauthorized);
+        assert_eq!(g.check(Some("new"), PEER), PinVerdict::Ok);
+
+        g.check(Some("bad"), PEER);
+        g.set_pin(None);
+        assert_eq!(g.check(None, PEER), PinVerdict::Ok);
+        assert!(g.failures.is_empty());
     }
 }

--- a/backend/vendor/localsend-rs/src/server/pin.rs
+++ b/backend/vendor/localsend-rs/src/server/pin.rs
@@ -57,7 +57,7 @@ impl PinGate {
     }
 }
 
-/// Length-leaking-free comparison without extra deps.
+/// Compare equal-length values without exiting on the first differing byte.
 fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;

--- a/backend/vendor/localsend-rs/src/server/server.rs
+++ b/backend/vendor/localsend-rs/src/server/server.rs
@@ -103,6 +103,22 @@ impl LocalSendServer {
         self.auto_accept.load(Ordering::Relaxed)
     }
 
+    /// Change receiver-side PIN protection without restarting the listener.
+    /// The new value applies to future authentication checks and resets all
+    /// failure counters associated with the previous credential.
+    pub async fn set_pin(&mut self, pin: Option<String>) -> crate::Result<()> {
+        let state = self
+            .state
+            .as_ref()
+            .ok_or_else(|| crate::error::LocalSendError::invalid_state("Server is not running"))?;
+        {
+            let mut state = state.write().await;
+            state.pin_gate.set_pin(pin.clone());
+        }
+        self.pin = pin;
+        Ok(())
+    }
+
     #[cfg(feature = "https")]
     pub fn set_tls_certificate(&mut self, cert: crate::crypto::TlsCertificate) {
         self.tls_cert = Some(cert);

--- a/backend/vendor/localsend-rs/tests/conformance_pin.rs
+++ b/backend/vendor/localsend-rs/tests/conformance_pin.rs
@@ -3,6 +3,7 @@ mod common;
 use localsend_rs::Protocol;
 use localsend_rs::server::LocalSendServer;
 use serde_json::json;
+use std::time::Duration;
 
 fn minimal_prepare_body() -> serde_json::Value {
     json!({
@@ -21,7 +22,7 @@ fn minimal_prepare_body() -> serde_json::Value {
 #[tokio::test]
 async fn pin_gate_returns_401_then_429_then_accepts_correct_pin() {
     let save = tempfile::tempdir().unwrap();
-    let (server, _events) = LocalSendServer::builder()
+    let (server, mut events) = LocalSendServer::builder()
         .alias("Pinned")
         .port(0)
         .save_dir(save.path())
@@ -36,6 +37,21 @@ async fn pin_gate_returns_401_then_429_then_accepts_correct_pin() {
     let base = format!("http://127.0.0.1:{port}/api/localsend/v2/prepare-upload");
     let http = reqwest::Client::new();
 
+    // A missing PIN is rejected without surfacing a transfer request and does
+    // not consume one of the three incorrect-PIN attempts.
+    let r = http
+        .post(&base)
+        .json(&minimal_prepare_body())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status(), 401);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), events.recv())
+            .await
+            .is_err()
+    );
+
     // wrong pin -> 401, three times
     for _ in 0..3 {
         let r = http
@@ -45,6 +61,11 @@ async fn pin_gate_returns_401_then_429_then_accepts_correct_pin() {
             .await
             .unwrap();
         assert_eq!(r.status(), 401);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), events.recv())
+                .await
+                .is_err()
+        );
     }
     // locked out -> 429 even with the right pin
     let r = http
@@ -54,6 +75,61 @@ async fn pin_gate_returns_401_then_429_then_accepts_correct_pin() {
         .await
         .unwrap();
     assert_eq!(r.status(), 429);
+}
+
+#[tokio::test]
+async fn pin_gate_protects_message_shaped_requests_before_events() {
+    let save = tempfile::tempdir().unwrap();
+    let (server, mut events) = LocalSendServer::builder()
+        .alias("Pinned Message")
+        .port(0)
+        .save_dir(save.path())
+        .protocol(Protocol::Http)
+        .pin("Text-1")
+        .auto_accept(true)
+        .build()
+        .await
+        .unwrap();
+    common::wait_for_http_info(server.port()).await;
+    let base = format!(
+        "http://127.0.0.1:{}/api/localsend/v2/prepare-upload",
+        server.port()
+    );
+    let mut body = minimal_prepare_body();
+    body["files"]["f1"]["fileType"] = json!("text/plain");
+    body["files"]["f1"]["preview"] = json!("protected message");
+    body["files"]["f1"]["size"] = json!(17);
+    let http = reqwest::Client::new();
+
+    let status = http
+        .post(format!("{base}?pin=wrong"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .status();
+    assert_eq!(status, 401);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), events.recv())
+            .await
+            .is_err()
+    );
+
+    let status = http
+        .post(format!("{base}?pin=Text-1"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .status();
+    assert_eq!(status, 204);
+    let event = tokio::time::timeout(Duration::from_secs(1), events.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        matches!(event, localsend_rs::server::ServerEvent::TextReceived { text, .. } if text == "protected message")
+    );
 }
 
 #[tokio::test]

--- a/backend/vendor/localsend-rs/tests/conformance_pin.rs
+++ b/backend/vendor/localsend-rs/tests/conformance_pin.rs
@@ -84,3 +84,72 @@ async fn correct_pin_passes() {
     assert!(body["sessionId"].is_string());
     assert!(body["files"]["f1"].is_string());
 }
+
+#[tokio::test]
+async fn live_pin_changes_apply_without_restart_and_clear_lockout() {
+    let save = tempfile::tempdir().unwrap();
+    let (mut server, _events) = LocalSendServer::builder()
+        .alias("Live PIN")
+        .port(0)
+        .save_dir(save.path())
+        .protocol(Protocol::Http)
+        .auto_accept(true)
+        .build()
+        .await
+        .unwrap();
+    let port = server.port();
+    common::wait_for_http_info(port).await;
+    let base = format!("http://127.0.0.1:{port}/api/localsend/v2/prepare-upload");
+    let http = reqwest::Client::new();
+    let empty = json!({
+        "info": minimal_prepare_body()["info"].clone(),
+        "files": {}
+    });
+
+    let status = http.post(&base).json(&empty).send().await.unwrap().status();
+    assert_eq!(status, 204);
+
+    server.set_pin(Some("old".to_string())).await.unwrap();
+    let status = http.post(&base).json(&empty).send().await.unwrap().status();
+    assert_eq!(status, 401);
+    for _ in 0..3 {
+        let status = http
+            .post(format!("{base}?pin=bad"))
+            .json(&empty)
+            .send()
+            .await
+            .unwrap()
+            .status();
+        assert_eq!(status, 401);
+    }
+    let status = http
+        .post(format!("{base}?pin=old"))
+        .json(&empty)
+        .send()
+        .await
+        .unwrap()
+        .status();
+    assert_eq!(status, 429);
+
+    server.set_pin(Some("new".to_string())).await.unwrap();
+    let status = http
+        .post(format!("{base}?pin=old"))
+        .json(&empty)
+        .send()
+        .await
+        .unwrap()
+        .status();
+    assert_eq!(status, 401);
+    let status = http
+        .post(format!("{base}?pin=new"))
+        .json(&empty)
+        .send()
+        .await
+        .unwrap()
+        .status();
+    assert_eq!(status, 204);
+
+    server.set_pin(None).await.unwrap();
+    let status = http.post(&base).json(&empty).send().await.unwrap().status();
+    assert_eq!(status, 204);
+}

--- a/backend/vendor/localsend-rs/tests/interop_upload.rs
+++ b/backend/vendor/localsend-rs/tests/interop_upload.rs
@@ -172,6 +172,67 @@ async fn uploads_in_memory_bytes_without_a_source_file() {
 }
 
 #[tokio::test]
+async fn authorized_upload_survives_a_live_pin_change() {
+    let save_dir = tempfile::tempdir().expect("save dir");
+    let (mut server, _events) = LocalSendServer::builder()
+        .alias("PIN Change Receiver")
+        .port(0)
+        .save_dir(save_dir.path())
+        .protocol(Protocol::Http)
+        .pin("Old-1")
+        .auto_accept(true)
+        .build()
+        .await
+        .expect("build");
+    let target = common::target_device(server.port());
+    common::wait_for_http_info(server.port()).await;
+
+    let payload = b"authorized before the PIN changed".to_vec();
+    let file_id = FileId::new();
+    let mut files = HashMap::new();
+    files.insert(
+        file_id.clone(),
+        FileMetadata {
+            id: file_id.clone(),
+            file_name: "survives.bin".into(),
+            size: payload.len() as u64,
+            file_type: "application/octet-stream".into(),
+            sha256: Some(sha256_from_bytes(&payload)),
+            preview: None,
+            metadata: None,
+        },
+    );
+    let client = LocalSendClient::new(DeviceInfo::new("Sender".into(), 0, Protocol::Http));
+    let prepared = client
+        .prepare_upload(&target, files, Some("Old-1"))
+        .await
+        .expect("prepare with old PIN");
+    let token = prepared.files.get(&file_id).expect("token");
+
+    server
+        .set_pin(Some("New-1".to_string()))
+        .await
+        .expect("live PIN change");
+    client
+        .upload_bytes(
+            &target,
+            &prepared.session_id,
+            &file_id,
+            token,
+            payload.clone(),
+            None,
+        )
+        .await
+        .expect("previously authorized upload");
+
+    assert_eq!(
+        std::fs::read(save_dir.path().join("survives.bin")).unwrap(),
+        payload
+    );
+    server.stop();
+}
+
+#[tokio::test]
 async fn upload_completes_when_progress_event_channel_is_not_drained() {
     let save_dir = tempfile::tempdir().expect("save dir");
     let src_dir = tempfile::tempdir().expect("src dir");

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "oma.nearby",
   "name": "Nearby",
-  "version": "1.0.7",
+  "version": "1.1.0-dev",
   "author": "jfg96",
   "description": "Native nearby sharing compatible with the LocalSend protocol",
   "kinds": [

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -24,6 +24,8 @@ const pendingText = {kind:"text",device:phone,text:"hello"}
 assert.equal(Model.outgoingCommand(null, "out-1", null), null)
 assert.deepEqual(Model.outgoingCommand(pendingFiles, "out-1", null), {command:"send_files",transfer_id:"out-1",device:phone,paths:["/tmp/a","/tmp/b"]})
 assert.deepEqual(Model.outgoingCommand(pendingText, "out-2", "123456"), {command:"send_text",transfer_id:"out-2",device:phone,text:"hello",pin:"123456"})
+assert.deepEqual(Model.outgoingCommand(pendingText, "out-3", "a+b & # % contraseña"),
+  {command:"send_text",transfer_id:"out-3",device:phone,text:"hello",pin:"a+b & # % contraseña"})
 assert.equal(Object.hasOwn(pendingText, "pin"), false)
 assert.equal(Model.viewAfterOutgoing(true, "success"), "incoming")
 assert.equal(Model.viewAfterOutgoing(false, "error"), "error")

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -36,6 +36,10 @@ assert.match(source, /onOpenedChanged[\s\S]*?if \(root\.viewState==="pin"\) pinI
   "reopening a pending PIN prompt must restore focus to its input")
 assert.match(source, /Component\.onDestruction:\s*if \(engine && viewRegistered\) engine\.viewClosed\(\)/,
   "a view torn down while open must release its claim on discovery")
+assert.match(source, /viewState\.indexOf\("incoming_pin_"\) === 0\) return "Receiver security"/,
+  "PIN screens must not inherit stale discovery status in their header")
+assert.equal((source.match(/text:"Back"/g) || []).length, 2,
+  "the device actions and PIN settings screens both need a visible mouse exit")
 
 assert.equal(source.includes("closeStdin"), false, "Quickshell Process does not expose closeStdin")
 assert.match(source, /onStarted:\s*\{[^}]*write\(root\.incomingText\);\s*stdinEnabled=false\s*\}/,
@@ -260,9 +264,27 @@ function callNames(state) {
   const enabled = panel({viewState: "incoming_pin_settings", incomingPinEnabled: true, selectedIndex: 1})
   enabled.activateCursor()
   assert.equal(callNames(enabled).at(-1), "requestDisableIncomingPin")
+  enabled.selectedIndex = 2
+  enabled.activateCursor()
+  assert.equal(callNames(enabled).at(-1), "cancelIncomingPinSettings",
+    "enabled PIN settings must expose Back to keyboard users too")
+  const disabledBack = panel({viewState: "incoming_pin_settings", incomingPinEnabled: false, selectedIndex: 1})
+  disabledBack.activateCursor()
+  assert.equal(callNames(disabledBack).at(-1), "cancelIncomingPinSettings",
+    "disabled PIN settings must expose Back to keyboard users too")
   const confirmation = panel({viewState: "incoming_pin_disable", selectedIndex: 1})
   confirmation.activateCursor()
   assert.equal(callNames(confirmation).at(-1), "confirmDisableIncomingPin")
+}
+
+{
+  const state = panel({viewState: "target", selectedIndex: 2})
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "clearTarget",
+    "device actions must expose Back to keyboard users too")
+  state.selectedIndex = 0
+  state.moveCursor(0, 9)
+  assert.equal(state.selectedIndex, 2, "device action cursor must stop on Back")
 }
 
 {

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -36,8 +36,14 @@ assert.match(source, /onOpenedChanged[\s\S]*?if \(root\.viewState==="pin"\) pinI
   "reopening a pending PIN prompt must restore focus to its input")
 assert.match(source, /Component\.onDestruction:\s*if \(engine && viewRegistered\) engine\.viewClosed\(\)/,
   "a view torn down while open must release its claim on discovery")
-assert.match(source, /viewState\.indexOf\("incoming_pin_"\) === 0\) return "Receiver security"/,
-  "PIN screens must not inherit stale discovery status in their header")
+assert.match(source, /viewState === "incoming_pin_settings"\) return incomingPinEnabled \? "Protection enabled" : "Protection disabled"/,
+  "PIN settings must expose their state in the hero instead of repeating it in the body")
+assert.match(source, /id:nearbyActions/,
+  "secondary Nearby actions should share one compact row")
+assert.equal(source.includes('PanelSectionHeader { text: "NEARBY"'), false,
+  "the device section must not repeat the panel title")
+assert.equal(source.includes('text:root.incomingPinEnabled?"PIN protection is enabled"'), false,
+  "PIN settings must not repeat the state already shown in the hero")
 assert.equal((source.match(/text:"Back"/g) || []).length, 2,
   "the device actions and PIN settings screens both need a visible mouse exit")
 
@@ -201,6 +207,8 @@ function callNames(state) {
   state.selectedIndex = 0
   state.activateCursor()
   assert.equal(callNames(state).at(-1), "declineIncoming")
+  state.moveCursor(1, 0)
+  assert.equal(state.selectedIndex, 1, "left and right must navigate a two-button action row")
 }
 
 {
@@ -231,6 +239,9 @@ function callNames(state) {
   assert.equal(state.selectedIndex, 3, "the cursor stops on incoming PIN settings after rescan")
   state.moveCursor(0, -9)
   assert.equal(state.selectedIndex, -1, "the cursor stops on the receiver switch above the list")
+  state.selectedIndex = 2
+  state.moveCursor(1, 0)
+  assert.equal(state.selectedIndex, 3, "left and right must navigate the compact Nearby action row")
   assert.equal(state.engine.calls.length, 0, "moving a cursor is local to one monitor")
 }
 
@@ -264,6 +275,10 @@ function callNames(state) {
   const enabled = panel({viewState: "incoming_pin_settings", incomingPinEnabled: true, selectedIndex: 1})
   enabled.activateCursor()
   assert.equal(callNames(enabled).at(-1), "requestDisableIncomingPin")
+  enabled.selectedIndex = 0
+  enabled.moveCursor(1, 0)
+  assert.equal(enabled.selectedIndex, 1,
+    "left and right must navigate the Change/Disable row")
   enabled.selectedIndex = 2
   enabled.activateCursor()
   assert.equal(callNames(enabled).at(-1), "cancelIncomingPinSettings",

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -95,6 +95,8 @@ const functionNames = [
   "syncOpenState", "toggleReceiver", "startDiscovery", "forceFullDiscovery",
   "chooseDevice", "acceptIncoming", "declineIncoming", "finishText", "finishTerminal",
   "cancelOutgoing", "cancelPin", "retryWithPin", "failWith", "noteTextCopied", "beginOutgoing",
+  "openIncomingPinSettings", "beginIncomingPinEdit", "requestDisableIncomingPin",
+  "cancelIncomingPinSettings", "submitIncomingPin", "confirmDisableIncomingPin",
   "goBack", "selectFiles", "sendClipboard", "copyReceivedText", "moveCursor", "activateCursor",
 ]
 
@@ -117,6 +119,12 @@ function stubEngine() {
     cancelOutgoing: record("cancelOutgoing"),
     cancelPin: record("cancelPin"),
     retryWithPin: record("retryWithPin"),
+    openIncomingPinSettings: record("openIncomingPinSettings"),
+    beginIncomingPinEdit: record("beginIncomingPinEdit"),
+    requestDisableIncomingPin: record("requestDisableIncomingPin"),
+    cancelIncomingPinSettings: record("cancelIncomingPinSettings"),
+    submitIncomingPin: record("submitIncomingPin"),
+    confirmDisableIncomingPin: record("confirmDisableIncomingPin"),
     failWith: record("failWith"),
     noteTextCopied: record("noteTextCopied"),
     beginOutgoing: record("beginOutgoing"),
@@ -136,6 +144,7 @@ function panel(initial = {}) {
     clipboard: {running: false, launched: false},
     clipboardWriter: {running: false, launched: false},
     pinInput: {text: "", forceActiveFocus: () => {}},
+    incomingPinInput: {text: "", forceActiveFocus: () => {}},
     keyCatcher: {forceActiveFocus: () => {}},
     close: () => closes.push(true),
     moduleName: "oma.nearby",
@@ -147,6 +156,9 @@ function panel(initial = {}) {
     devices: [],
     selectedDevice: {fingerprint: "phone", alias: "Phone"},
     viewState: "target",
+    receiverEnabled: true,
+    backendReady: true,
+    incomingPinEnabled: false,
     ...initial,
   }
   context.engine = engine
@@ -172,6 +184,10 @@ function callNames(state) {
   state.activateCursor()
   assert.equal(callNames(state).at(-1), "toggleReceiver",
     "the cursor above the list is the receiver switch")
+  state.selectedIndex = 3
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "openIncomingPinSettings",
+    "the entry after rescan opens incoming PIN settings")
 }
 
 {
@@ -208,7 +224,7 @@ function callNames(state) {
   state.moveCursor(0, 1)
   assert.equal(state.selectedIndex, 1)
   state.moveCursor(0, 5)
-  assert.equal(state.selectedIndex, 2, "the cursor stops on the rescan entry past the last device")
+  assert.equal(state.selectedIndex, 3, "the cursor stops on incoming PIN settings after rescan")
   state.moveCursor(0, -9)
   assert.equal(state.selectedIndex, -1, "the cursor stops on the receiver switch above the list")
   assert.equal(state.engine.calls.length, 0, "moving a cursor is local to one monitor")
@@ -221,10 +237,32 @@ function callNames(state) {
   const pin = panel({viewState: "pin"})
   pin.goBack()
   assert.equal(callNames(pin).at(-1), "cancelPin")
+  const incomingPin = panel({viewState: "incoming_pin_settings"})
+  incomingPin.goBack()
+  assert.equal(callNames(incomingPin).at(-1), "cancelIncomingPinSettings")
   const nearby = panel({viewState: "nearby"})
   nearby.goBack()
   assert.equal(nearby.closes.length, 1, "back from the root view closes this monitor's popup")
   assert.equal(nearby.engine.calls.length, 0)
+}
+
+{
+  const state = panel({viewState: "incoming_pin_edit"})
+  state.incomingPinInput.text = "Abc-_.~09"
+  state.submitIncomingPin()
+  assert.deepEqual(state.engine.calls.at(-1), ["submitIncomingPin", "Abc-_.~09"])
+}
+
+{
+  const disabled = panel({viewState: "incoming_pin_settings", incomingPinEnabled: false, selectedIndex: 0})
+  disabled.activateCursor()
+  assert.equal(callNames(disabled).at(-1), "beginIncomingPinEdit")
+  const enabled = panel({viewState: "incoming_pin_settings", incomingPinEnabled: true, selectedIndex: 1})
+  enabled.activateCursor()
+  assert.equal(callNames(enabled).at(-1), "requestDisableIncomingPin")
+  const confirmation = panel({viewState: "incoming_pin_disable", selectedIndex: 1})
+  confirmation.activateCursor()
+  assert.equal(callNames(confirmation).at(-1), "confirmDisableIncomingPin")
 }
 
 {

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -18,6 +18,12 @@ assert.match(source, /bar\.shell\.serviceFor\(manifestPluginId\)/,
   "the widget must read its state from the single service instance")
 assert.match(source, /manageIpc:\s*false/,
   "the base panel's IPC handler must stay off so the service owns the target")
+assert.equal(source.includes("Qt.ImhDigitsOnly"), false,
+  "the outgoing PIN prompt must accept the same text values as LocalSend")
+assert.equal(source.includes("RegularExpressionValidator { regularExpression: /[0-9]*/ }"), false,
+  "the outgoing PIN prompt must not silently reject non-numeric PINs")
+assert.doesNotMatch(source, /id:\s*pinInput[^\n]*maximumLength:\s*32/,
+  "the outgoing PIN prompt must not retain its old 32-character limit")
 for (const owned of ["backendRestart", "receiverShutdownFallback", "handleEvent(", "handleBackendExit("]) {
   assert.equal(source.includes(owned), false,
     `${owned} is engine state and must not be duplicated per monitor`)

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -34,6 +34,8 @@ assert.match(source, /onCursorRequested\(index\)\s*\{\s*root\.selectedIndex = in
   "the engine asks each view to move its own cursor rather than holding one")
 assert.match(source, /onOpenedChanged[\s\S]*?if \(root\.viewState==="pin"\) pinInput\.forceActiveFocus\(\)/,
   "reopening a pending PIN prompt must restore focus to its input")
+assert.match(source, /onOpenedChanged:[\s\S]*?else \{ clearSecretInputs\(\); syncOpenState\(\) \}/,
+  "closing a popup must clear locally retained PIN values")
 assert.match(source, /Component\.onDestruction:\s*if \(engine && viewRegistered\) engine\.viewClosed\(\)/,
   "a view torn down while open must release its claim on discovery")
 assert.match(source, /viewState === "incoming_pin_settings"\) return incomingPinEnabled \? "Protection enabled" : "Protection disabled"/,
@@ -107,6 +109,7 @@ const functionNames = [
   "cancelOutgoing", "cancelPin", "retryWithPin", "failWith", "noteTextCopied", "beginOutgoing",
   "openIncomingPinSettings", "beginIncomingPinEdit", "requestDisableIncomingPin",
   "cancelIncomingPinSettings", "submitIncomingPin", "confirmDisableIncomingPin",
+  "clearSecretInputs",
   "goBack", "selectFiles", "sendClipboard", "copyReceivedText", "moveCursor", "activateCursor",
 ]
 
@@ -308,6 +311,15 @@ function callNames(state) {
   state.retryWithPin()
   assert.deepEqual(state.engine.calls.at(-1), ["retryWithPin", "123456"],
     "the PIN is read from this monitor's field and handed to the shared engine")
+}
+
+{
+  const state = panel()
+  state.pinInput.text = "outgoing-secret"
+  state.incomingPinInput.text = "incoming-secret"
+  state.clearSecretInputs()
+  assert.equal(state.pinInput.text, "")
+  assert.equal(state.incomingPinInput.text, "")
 }
 
 {

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -580,6 +580,7 @@ function incoming(requestId, sender = requestId) {
   state.handleBackendExit(1)
   assert.match(state.errorText, /security settings are invalid/i)
   assert.match(state.errorText, /settings\.json/)
+  assert.match(state.errorText, /XDG state directory/i)
   assert.deepEqual(restarts, [],
     "a persistent security configuration error must fail closed without a retry loop")
 }

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -228,6 +228,25 @@ function incoming(requestId, sender = requestId) {
 }
 
 {
+  const state = engine({viewState: "incoming_pin_edit"})
+  state.submitIncomingPin("Safe-1")
+  state.handleEvent(incoming("raced"))
+  state.handleEvent({event: "incoming_pin_state", enabled: true})
+  assert.equal(state.viewState, "incoming",
+    "a late PIN-save confirmation must not hide an incoming transfer that preempted settings")
+  assert.equal(state.incoming.requestId, "raced")
+}
+
+{
+  const state = engine({viewState: "incoming_pin_edit"})
+  const before = state.signals.incomingPinCleared
+  state.handleEvent({event: "incoming_text", sessionId: "text", sender: "Alice", text: "hello"})
+  assert.equal(state.viewState, "text")
+  assert.ok(state.signals.incomingPinCleared > before,
+    "incoming text that preempts PIN settings must clear the local secret field")
+}
+
+{
   const state = engine()
   state.handleEvent(incoming("a"))
   state.handleEvent(incoming("b"))

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -219,6 +219,22 @@ function incoming(requestId, sender = requestId) {
 }
 
 {
+  const state = engine({
+    backendReady: false,
+    viewState: "incoming_pin_settings",
+    incomingPinEnabled: true,
+  })
+  state.beginIncomingPinEdit()
+  state.requestDisableIncomingPin()
+  state.submitIncomingPin("Safe-1")
+  state.confirmDisableIncomingPin()
+  assert.equal(state.viewState, "incoming_pin_settings")
+  assert.equal(state.incomingPinUpdating, false)
+  assert.equal(state.sent.length, 0,
+    "receiver security controls must not queue an update while the helper is unavailable")
+}
+
+{
   const state = engine({viewState: "incoming_pin_edit"})
   const before = state.signals.incomingPinCleared
   state.handleEvent(incoming("authenticated"))
@@ -511,6 +527,14 @@ function incoming(requestId, sender = requestId) {
   assert.equal(state.incoming, null)
   assert.equal(state.activeIncomingSession, "")
   assert.equal(state.viewState, "error", "helper exit must not leave an empty incoming view")
+}
+
+{
+  const state = engine({viewState: "incoming_pin_edit"})
+  state.handleBackendExit(1)
+  assert.equal(state.viewState, "error",
+    "helper exit must not leave receiver security controls connected to nothing")
+  assert.match(state.errorText, /receiver security/i)
 }
 
 {

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -80,6 +80,8 @@ const functionNames = [
   "viewOpened", "viewClosed",
   "send", "bindBackendRunning", "persistReceiverEnabled", "toggleReceiver", "finishReceiverShutdown",
   "startDiscovery", "forceFullDiscovery", "stopDiscovery", "chooseDevice", "clearTarget",
+  "openIncomingPinSettings", "beginIncomingPinEdit", "requestDisableIncomingPin",
+  "cancelIncomingPinSettings", "submitIncomingPin", "confirmDisableIncomingPin",
   "failWith", "cancelOutgoing", "noteTextCopied",
   "clearPendingOutgoing", "dispatchPendingOutgoing", "beginOutgoing", "retryWithPin",
   "showPinPrompt", "cancelPin", "acceptIncoming", "declineIncoming",
@@ -90,7 +92,7 @@ const functionNames = [
 function engine(initial = {}) {
   const sent = []
   const cursors = []
-  const signals = {pinCleared: 0, pinFocusRequested: 0, focusRestoreRequested: 0}
+  const signals = {pinCleared: 0, pinFocusRequested: 0, incomingPinCleared: 0, incomingPinFocusRequested: 0, focusRestoreRequested: 0}
   const context = {
     Model,
     Date: {now: () => 1000},
@@ -103,6 +105,8 @@ function engine(initial = {}) {
     cursorRequested: index => cursors.push(index),
     pinCleared: () => { signals.pinCleared++ },
     pinFocusRequested: () => { signals.pinFocusRequested++ },
+    incomingPinCleared: () => { signals.incomingPinCleared++ },
+    incomingPinFocusRequested: () => { signals.incomingPinFocusRequested++ },
     focusRestoreRequested: () => { signals.focusRestoreRequested++ },
     shell: null,
     moduleEntryId: "oma.nearby",
@@ -135,6 +139,10 @@ function engine(initial = {}) {
     outgoingTransferId: "",
     pendingOutgoing: null,
     pinError: "",
+    incomingPinEnabled: false,
+    incomingPinUpdating: false,
+    pendingIncomingPinEnabled: null,
+    incomingPinError: "",
     transferSequence: 0,
     ...initial,
   }
@@ -165,6 +173,58 @@ function engine(initial = {}) {
 
 function incoming(requestId, sender = requestId) {
   return {event: "incoming_request", requestId, sender, files: [{name: `${requestId}.txt`}], total: 1}
+}
+
+{
+  const state = engine({viewState: "nearby"})
+  state.handleEvent({event: "incoming_pin_state", enabled: false})
+  assert.equal(state.incomingPinEnabled, false)
+  state.openIncomingPinSettings()
+  assert.equal(state.viewState, "incoming_pin_settings")
+  state.beginIncomingPinEdit()
+  assert.equal(state.viewState, "incoming_pin_edit")
+
+  state.submitIncomingPin("bad pin")
+  assert.equal(state.sent.some(command => command.command === "set_incoming_pin"), false)
+  assert.match(state.incomingPinError, /1–64/)
+  assert.ok(state.signals.incomingPinFocusRequested > 0)
+
+  state.submitIncomingPin("Abc-_.~09")
+  assert.deepEqual(state.sent.at(-1), {command: "set_incoming_pin", pin: "Abc-_.~09"})
+  assert.equal(state.incomingPinUpdating, true)
+  assert.equal(Object.hasOwn(state, "incomingPin"), false,
+    "the service must never retain a readable copy of the submitted PIN")
+  state.handleEvent({event: "incoming_pin_state", enabled: true})
+  assert.equal(state.incomingPinEnabled, true)
+  assert.equal(state.incomingPinUpdating, false)
+  assert.equal(state.viewState, "incoming_pin_settings")
+  assert.ok(state.signals.incomingPinCleared > 0)
+
+  state.requestDisableIncomingPin()
+  assert.equal(state.viewState, "incoming_pin_disable")
+  state.confirmDisableIncomingPin()
+  assert.deepEqual(state.sent.at(-1), {command: "disable_incoming_pin"})
+  state.handleEvent({event: "incoming_pin_state", enabled: false})
+  assert.equal(state.incomingPinEnabled, false)
+}
+
+{
+  const state = engine({viewState: "incoming_pin_edit"})
+  state.submitIncomingPin("Safe-1")
+  state.handleEvent({event: "incoming_pin_update_failed", message: "Unable to update incoming PIN"})
+  assert.equal(state.incomingPinUpdating, false)
+  assert.equal(state.pendingIncomingPinEnabled, null)
+  assert.equal(state.incomingPinError, "Unable to update incoming PIN")
+  assert.ok(state.signals.incomingPinCleared > 0)
+}
+
+{
+  const state = engine({viewState: "incoming_pin_edit"})
+  const before = state.signals.incomingPinCleared
+  state.handleEvent(incoming("authenticated"))
+  assert.equal(state.viewState, "incoming")
+  assert.ok(state.signals.incomingPinCleared > before,
+    "an incoming request that preempts PIN settings must clear the local secret field")
 }
 
 {
@@ -489,6 +549,20 @@ function incoming(requestId, sender = requestId) {
   assert.match(state.errorText, /another LocalSend receiver/i)
   assert.match(state.errorText, /quit it|close it/i,
     "the final message must tell the user how to release the port")
+}
+
+{
+  const restarts = []
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 0, interval: 0, restart() { restarts.push(true) }, stop: () => {}},
+  })
+  state.handleEvent({event: "startup_failed", code: "receiver_security_settings_invalid"})
+  state.handleBackendExit(1)
+  assert.match(state.errorText, /security settings are invalid/i)
+  assert.match(state.errorText, /settings\.json/)
+  assert.deepEqual(restarts, [],
+    "a persistent security configuration error must fail closed without a retry loop")
 }
 
 {


### PR DESCRIPTION
## Summary

- add persistent incoming PIN protection with live enable, change, and disable controls
- align receiver authentication and lockout behavior with the official LocalSend implementation
- safely encode general outgoing PIN values and preserve already-authorized transfers across PIN changes
- store receiver security settings with private permissions, atomic replacement, and fail-closed startup validation
- simplify the Nearby panel, complete mouse and keyboard navigation, and clear local PIN fields when the popup closes

## Security and compatibility

- authentication runs before sessions, receiver events, or approval prompts
- three incorrect attempts lock out the source IP; missing PIN requests do not consume attempts
- failed persistence leaves the previous live PIN and lockout state unchanged
- successful live changes do not restart the listener or discovery
- incoming PINs use the LocalSend-compatible unreserved profile documented in the repository
- the saved PIN is never returned to QML or written to logs

## Validation

- `node tests/model.test.js`
- `node tests/panel-state.test.js`
- `node tests/service-state.test.js`
- `cargo fmt --manifest-path backend/Cargo.toml --all -- --check`
- `cargo check --locked --manifest-path backend/Cargo.toml`
- `cargo test --locked --manifest-path backend/Cargo.toml` — 36 passed
- `cargo test --locked --manifest-path backend/vendor/localsend-rs/Cargo.toml --features https` — 72 passed, 1 external-peer test ignored, all integration suites passed
- release build completed and the development plugin was loaded successfully on Omarchy
- real-device smoke test completed successfully with LocalSend on the user's phone

The broader interoperability matrix documented in `ROBUSTNESS.md`, including recording exact mobile OS and LocalSend versions, remains a pre-release requirement.
