### PR TITLE
fix: give the hero a label instead of a cropped sentence

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -68,7 +68,10 @@ Panel {
   readonly property string heroMetaText: {
     if (viewState === "nearby") {
       if (!receiverEnabled) return "Turned off"
-      if (!backendReady) return errorText || statusText
+      // statusText, never errorText: this line is uppercased and letterspaced,
+      // so a full sentence crops mid-word and the body below is already saying
+      // the same thing in full.
+      if (!backendReady) return statusText
       return nearbyPhrases[nearbyPhraseIndex % nearbyPhrases.length]
     }
     if (viewState === "incoming_pin_settings") return incomingPinEnabled ? "Protection enabled" : "Protection disabled"

--- a/Service.qml
+++ b/Service.qml
@@ -229,6 +229,11 @@ Item {
     incomingPinUpdating=true; pendingIncomingPinEnabled=false; incomingPinError=""
     send({command:"disable_incoming_pin"})
   }
+  // The hero gets a short status and the body gets the detail. Assigning one
+  // sentence to both is what cropped it: the hero line is uppercased and
+  // letterspaced, so anything longer than a few words ends in an ellipsis
+  // partway through a word and tells the user less than the icon already did.
+  function reportFailure(summary, detail) { statusText=summary; errorText=detail }
   function failWith(message) { viewState="error"; errorText=message; statusText=errorText }
   function cancelOutgoing() { send({command:"cancel_outgoing",transfer_id:outgoingTransferId}) }
   function noteTextCopied() { if (viewState !== "text") return; viewState="success"; statusText="Received" }
@@ -314,21 +319,22 @@ Item {
       // other pre-ready failures remain generic. Both keep the existing
       // bounded retry schedule so a transient conflict can recover.
       if (backendStartupFailureCode === "receiver_security_settings_invalid") {
-        errorText = "Nearby security settings are invalid. Repair or remove Nearby's settings.json in your XDG state directory."
+        reportFailure("Security settings invalid",
+          "Nearby security settings are invalid. Repair or remove Nearby's settings.json in your XDG state directory.")
       } else if (backendRestart.attempts < 4) {
-        errorText = "Nearby receiver could not start. Retrying…"
+        reportFailure("Retrying…", "Nearby receiver could not start. Retrying…")
       } else if (backendStartupFailureCode === "receiver_port_in_use") {
         var port = backendStartupFailurePort > 0 ? backendStartupFailurePort : 53317
-        errorText = "LocalSend receiver port " + port + " is already in use. Another LocalSend receiver on this computer may be running. Quit it and enable Nearby again."
+        reportFailure("Port " + port + " in use",
+          "LocalSend receiver port " + port + " is already in use. Another LocalSend receiver on this computer may be running. Quit it and enable Nearby again.")
       } else {
-        errorText = "Nearby receiver could not start."
+        reportFailure("Could not start", "Nearby receiver could not start.")
       }
-      statusText=errorText
     } else {
-      errorText=code===0 ? "Receiver stopped" : "Receiver unavailable"
-      statusText=errorText
-      if (viewState.indexOf("incoming_pin_")===0) { viewState="error"; errorText="Nearby backend stopped while updating receiver security"; statusText=errorText }
-      else if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; errorText="Nearby backend stopped during transfer"; statusText=errorText }
+      reportFailure(code===0 ? "Receiver stopped" : "Receiver unavailable",
+        code===0 ? "Receiver stopped" : "Receiver unavailable")
+      if (viewState.indexOf("incoming_pin_")===0) { viewState="error"; reportFailure("Backend stopped", "Nearby backend stopped while updating receiver security") }
+      else if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; reportFailure("Backend stopped", "Nearby backend stopped during transfer") }
     }
     if (backendStartupFailureCode !== "receiver_security_settings_invalid" && backendRestart.attempts < 4) { backendRestart.attempts++; backendRestart.interval=Math.min(30000,1000*Math.pow(2,backendRestart.attempts-1)); backendRestart.restart() }
   }
@@ -343,8 +349,7 @@ Item {
       if (!Model.helperVersionMatches(pluginVersion, event.helperVersion)) {
         backendReady=false
         backendVersionMismatch=true
-        errorText="Nearby backend version mismatch. Run the Nearby installer again."
-        statusText=errorText
+        reportFailure("Helper out of date", "Nearby backend version mismatch. Run the Nearby installer again.")
         send({command:"shutdown"})
         return
       }
@@ -427,8 +432,8 @@ Item {
       // running counts as one that failed to launch.
       if (!root.receiverEnabled || root.pluginVersion === "") return
       root.backendReady=false
-      root.errorText="Nearby helper is missing. Run the Nearby installer again or build it with ./build.sh."
-      root.statusText=root.errorText
+      root.reportFailure("Helper missing",
+        "Nearby helper is missing. Run the Nearby installer again or build it with ./build.sh.")
     }
     onExited: function(code) { root.handleBackendExit(code) }
   }

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -63,6 +63,13 @@ assert.match(source, /command:\s*\["omarchy-file-select"/,
   "the file chooser must be omarchy-file-select")
 assert.equal(/code\s*===?\s*127/.test(source), false,
   "no shell runs on our behalf, so a missing command never reports exit code 127")
+
+// The hero is uppercased and letterspaced, so it takes the short status the
+// engine sets and never the full error sentence, which cropped mid-word.
+assert.match(source, /if \(!backendReady\) return statusText/,
+  "the hero must show the short status")
+assert.equal(source.includes("return errorText || statusText"), false,
+  "falling back to the long error text is what put a cropped sentence in the hero")
 for (const launcher of ["picker", "clipboard", "clipboardWriter"]) {
   assert.match(source, new RegExp(`onRunningChanged:\\s*if\\s*\\(!running && !${launcher}\\.launched`),
     `${launcher} must report a command that never launched, which Quickshell signals by ` +

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -86,7 +86,7 @@ const functionNames = [
   "clearPendingOutgoing", "dispatchPendingOutgoing", "beginOutgoing", "retryWithPin",
   "showPinPrompt", "cancelPin", "acceptIncoming", "declineIncoming",
   "finishIncoming", "finishOutgoing", "finishText", "finishTerminal",
-  "handleBackendExit", "handleEvent",
+  "handleBackendExit", "handleEvent", "reportFailure",
 ]
 
 function engine(initial = {}) {
@@ -169,6 +169,67 @@ function engine(initial = {}) {
   state.receiverEnabled = true
   assert.equal(state.backend.running.callback(), true,
     "the restored binding must make OFF -> ON eligible to start again")
+}
+
+// The hero renders statusText uppercased and letterspaced, and every failure
+// path assigned the same sentence to statusText and errorText. A sentence does
+// not fit there: it was cropped mid-word, so the one line the user saw first
+// said less than the icon beside it. The label and the detail are now separate
+// strings, and the hero takes the label.
+{
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 4, interval: 0, restart: () => {}, stop: () => {}},
+    backendStartupFailureCode: "receiver_port_in_use", backendStartupFailurePort: 53317,
+    backend: {running: false, write: () => {}},
+  })
+  state.root = state
+  state.handleBackendExit(1)
+  assert.equal(state.statusText, "Port 53317 in use")
+  assert.match(state.errorText, /Another LocalSend receiver/,
+    "the body keeps the advice the label has no room for")
+  assert.notEqual(state.statusText, state.errorText)
+}
+
+{
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 4, interval: 0, restart: () => {}, stop: () => {}},
+    backendStartupFailureCode: "receiver_security_settings_invalid",
+    backend: {running: false, write: () => {}},
+  })
+  state.root = state
+  state.handleBackendExit(1)
+  assert.equal(state.statusText, "Security settings invalid")
+  assert.match(state.errorText, /settings\.json/)
+  assert.notEqual(state.statusText, state.errorText)
+}
+
+{
+  const state = engine({pluginVersion: "1.1.0", backendReady: false, viewState: "nearby"})
+  state.handleEvent({event: "ready", helperVersion: "1.0.7"})
+  assert.equal(state.statusText, "Helper out of date")
+  assert.match(state.errorText, /Run the Nearby installer again/)
+  assert.notEqual(state.statusText, state.errorText)
+}
+
+// Whatever a failure path sets, the label has to survive the hero's transform.
+// Twenty-four characters is what the popup fits at its default width.
+for (const [name, setup] of [
+  ["port conflict", {backendStartupFailureCode: "receiver_port_in_use", backendStartupFailurePort: 53317}],
+  ["invalid settings", {backendStartupFailureCode: "receiver_security_settings_invalid"}],
+  ["generic startup failure", {backendStartupFailureCode: ""}],
+]) {
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 4, interval: 0, restart: () => {}, stop: () => {}},
+    backend: {running: false, write: () => {}},
+    ...setup,
+  })
+  state.root = state
+  state.handleBackendExit(1)
+  assert.ok(state.statusText.length <= 26,
+    `${name} label must fit the hero, got ${state.statusText.length} characters: ${state.statusText}`)
 }
 
 function incoming(requestId, sender = requestId) {


### PR DESCRIPTION
Refs #7. First of a stacked series of four; this one stands alone and is not specific to the helper problem in that issue.

## Problem

Every failure path assigns the same string to `statusText` and `errorText`, and `Panel.qml` renders `statusText` in the hero, uppercased and letterspaced. A sentence does not fit there. The port conflict, the longest of them, arrives as

```
LOCALSEND RECEIVER PORT 53317 IS ALRE…
```

so the first line the user reads is cut mid-word and carries less than the icon beside it, while the body below repeats the whole text anyway. The invalid-settings message and the version mismatch crop the same way.

## Change

`reportFailure(summary, detail)` sets a short label for the hero and keeps the sentence for the body, and the hero stops falling back to `errorText`. No message text is lost — the advice moves to the line that has room for it.

| before (hero) | after (hero) |
| --- | --- |
| `LOCALSEND RECEIVER PORT 53317 IS ALRE…` | `PORT 53317 IN USE` |
| `NEARBY SECURITY SETTINGS ARE INVALID. …` | `SECURITY SETTINGS INVALID` |
| `NEARBY BACKEND VERSION MISMATCH. RUN T…` | `HELPER OUT OF DATE` |
| `NEARBY HELPER IS MISSING. RUN THE NEA…` | `HELPER MISSING` |

## Tests

`tests/service-state.test.js` asserts the label and the detail for the port conflict, the invalid settings and the mismatch, that they are never the same string, and that every startup-failure label fits the hero. `tests/panel-state.test.js` asserts the hero reads `statusText` and no longer falls back. All fail against the pre-fix source for the expected reason.

## Verification

`node tests/model.test.js`, `node tests/panel-state.test.js`, `node tests/service-state.test.js`, `cargo fmt --check`, `cargo check --locked`, `cargo test --locked`, and the vendored `localsend-rs` suite with `--features https` all pass.

Smoke-tested on Omarchy with Quattro: the version mismatch and the recovered state both render correctly in the popup. Real-device LocalSend transfers are untouched and were not re-tested.

## Note on versioning

`main` is on the v1.1.0 release commit, so per `AGENTS.md` this needs the cycle opened to `1.1.2-dev`. I have left that out deliberately — asked in #7 whether you would rather do it yourself, since upstream keeps it in its own `docs:` commit.