### PR TITLE
feat: require a minimum helper version instead of an exact one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.1.1-dev
+
 ## 1.1.0
 
 - Add a user-configured, persistent PIN for incoming text and file transfers.

--- a/Model.js
+++ b/Model.js
@@ -168,6 +168,68 @@ function helperVersionMatches(pluginVersion, helperVersion) {
   return String(pluginVersion || "") !== "" && String(pluginVersion) === String(helperVersion || "")
 }
 
+// Nearby's release process only ever produces MAJOR.MINOR.PATCH with an
+// optional prerelease suffix, so that is all this reads. Anything else is
+// null, which callers treat as unknown rather than as equal: a version that
+// cannot be read is not one the plugin can vouch for.
+function parseVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(String(value || "").trim())
+  if (!match) return null
+  return {
+    release: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split(".") : []
+  }
+}
+
+// SemVer precedence: numeric fields compare as numbers, a prerelease sorts
+// before the release it leads up to, and prerelease identifiers compare as
+// numbers when both are numeric and as text otherwise.
+function compareVersions(left, right) {
+  const a = parseVersion(left)
+  const b = parseVersion(right)
+  if (!a || !b) return null
+  for (var i = 0; i < 3; i++) {
+    if (a.release[i] !== b.release[i]) return a.release[i] < b.release[i] ? -1 : 1
+  }
+  if (a.prerelease.length === 0 || b.prerelease.length === 0) {
+    if (a.prerelease.length === b.prerelease.length) return 0
+    return a.prerelease.length === 0 ? 1 : -1
+  }
+  const longest = Math.max(a.prerelease.length, b.prerelease.length)
+  for (var j = 0; j < longest; j++) {
+    if (j >= a.prerelease.length) return -1
+    if (j >= b.prerelease.length) return 1
+    const x = a.prerelease[j]
+    const y = b.prerelease[j]
+    const xNumeric = /^\d+$/.test(x)
+    const yNumeric = /^\d+$/.test(y)
+    if (xNumeric && yNumeric) {
+      if (Number(x) !== Number(y)) return Number(x) < Number(y) ? -1 : 1
+      continue
+    }
+    if (xNumeric !== yNumeric) return xNumeric ? -1 : 1
+    if (x !== y) return x < y ? -1 : 1
+  }
+  return 0
+}
+
+// A helper is good enough when it is at least the oldest one this plugin knows
+// how to drive. Requiring the exact shipped version instead broke the plugin on
+// every release: `omarchy plugin update` moves the source and cannot move the
+// binary, because bin/ is not tracked, so a plugin one version ahead of a
+// helper it could still talk to refused to run at all. An unreadable version on
+// either side is still a refusal.
+function helperSatisfies(requiredVersion, helperVersion) {
+  const order = compareVersions(helperVersion, requiredVersion)
+  return order !== null && order >= 0
+}
+
+// Usable but behind: worth offering an update, not worth stopping for.
+function helperUpdateAvailable(pluginVersion, helperVersion) {
+  const order = compareVersions(helperVersion, pluginVersion)
+  return order !== null && order < 0
+}
+
 function manifestVersion(text, pluginId) {
   try {
     const manifest = JSON.parse(String(text || ""))
@@ -178,4 +240,18 @@ function manifestVersion(text, pluginId) {
   }
 }
 
-if (typeof module !== "undefined") module.exports = { parseLine, upsertDevice, snapshotDevices, iconFor, formatBytes, incomingSummary, enqueueIncoming, removeIncoming, currentIncoming, outgoingCommand, viewAfterOutgoing, barEntry, hasStringBarEntry, promoteStringBarEntry, receiverEnabledIn, helperVersionMatches, manifestVersion }
+// The oldest helper this plugin can drive, declared beside the version it
+// ships with. Absent means "the shipped version", which is the rule the plugin
+// followed before the field existed and the safe reading of a manifest that
+// predates it.
+function manifestMinHelperVersion(text, pluginId) {
+  try {
+    const manifest = JSON.parse(String(text || ""))
+    if (String(manifest.id || "") !== String(pluginId || "")) return ""
+    return String(manifest.minHelperVersion || "")
+  } catch (_) {
+    return ""
+  }
+}
+
+if (typeof module !== "undefined") module.exports = { parseLine, upsertDevice, snapshotDevices, iconFor, formatBytes, incomingSummary, enqueueIncoming, removeIncoming, currentIncoming, outgoingCommand, viewAfterOutgoing, barEntry, hasStringBarEntry, promoteStringBarEntry, receiverEnabledIn, helperVersionMatches, compareVersions, helperSatisfies, helperUpdateAvailable, manifestVersion, manifestMinHelperVersion }

--- a/Panel.qml
+++ b/Panel.qml
@@ -136,6 +136,24 @@ Panel {
   function sendClipboard() { if (!selectedDevice || clipboard.running) return; clipboard.launched=false; clipboard.running = true }
   function copyReceivedText() { clipboardWriter.launched=false; clipboardWriter.running=true }
 
+  // The kit's Button already paints its own mouse hover from containsMouse.
+  // `hasCursor` is this panel's keyboard cursor, and the handlers only ever
+  // took it: pointing the cursor at whatever the mouse touched and never
+  // letting go, so the last button the pointer crossed stayed lit after it had
+  // moved away, and two things looked hovered at once.
+  //
+  // Taking it on enter and releasing it on leave keeps one highlight, under the
+  // pointer. selectedIndex survives the release so an arrow key resumes from
+  // where the mouse left off rather than from the top.
+  //
+  // The release is guarded by index because entering the next button can be
+  // delivered before leaving the previous one; unguarded, that order would
+  // clear the highlight on the button the pointer is now sitting on.
+  function noteHover(on, index) {
+    if (on) { cursorActive = true; selectedIndex = index }
+    else if (selectedIndex === index) cursorActive = false
+  }
+
   function moveCursor(dx, dy) {
     cursorActive = true
     if (viewState === "nearby") {
@@ -277,7 +295,7 @@ Panel {
             checked: root.receiverEnabled
             hasCursor: root.cursorActive && root.selectedIndex < 0
             foreground: root.foreground
-            onHovered: function(on) { if (on) { root.cursorActive=true; root.selectedIndex=-1 } }
+            onHovered: function(on) { root.noteHover(on, -1) }
             onToggled: root.toggleReceiver()
             PanelToolTip { visible: parent.containsMouse; text: root.receiverEnabled ? "Turn Nearby off" : "Turn Nearby on"; fontFamily:root.fontFamily }
           }
@@ -290,21 +308,21 @@ Panel {
           Text { visible: root.devices.length===0; width:parent.width; textFormat:Text.PlainText; text: !root.receiverEnabled ? "Nearby is turned off" : (root.discoveryActive ? "Finding devices…" : (root.backendReady ? "No devices nearby" : root.errorText)); wrapMode:Text.Wrap; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body; topPadding:Style.space(12); bottomPadding:Style.space(12) }
           Repeater {
             model: root.devices
-            Button { required property var modelData; required property int index; width:parent.width; leftAlign:true; bordered:false; iconText:Model.iconFor(modelData.deviceType); text:modelData.alias; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===index; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=index}}; onClicked:root.chooseDevice(index) }
+            Button { required property var modelData; required property int index; width:parent.width; leftAlign:true; bordered:false; iconText:Model.iconFor(modelData.deviceType); text:modelData.alias; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===index; onHovered:function(v){root.noteHover(v,index)}; onClicked:root.chooseDevice(index) }
           }
           Row {
             id:nearbyActions; visible:root.receiverEnabled&&root.backendReady; width:parent.width; spacing:Style.space(8)
-            Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰑐"; text:"Rescan"; tooltipText:"Search for new devices"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=root.devices.length}}; onClicked:root.forceFullDiscovery() }
-            Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰌾"; text:"PIN · "+(root.incomingPinEnabled?"On":"Off"); tooltipText:"Incoming PIN settings"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length+1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=root.devices.length+1}}; onClicked:root.openIncomingPinSettings() }
+            Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰑐"; text:"Rescan"; tooltipText:"Search for new devices"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length; onHovered:function(v){root.noteHover(v,root.devices.length)}; onClicked:root.forceFullDiscovery() }
+            Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰌾"; text:"PIN · "+(root.incomingPinEnabled?"On":"Off"); tooltipText:"Incoming PIN settings"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length+1; onHovered:function(v){root.noteHover(v,root.devices.length+1)}; onClicked:root.openIncomingPinSettings() }
           }
         }
 
         Column {
           visible: root.viewState === "target"; width:parent.width; spacing:Style.space(6)
           PanelSectionHeader { text:"SEND"; foreground:root.foreground; fontFamily:root.fontFamily }
-          Button { width:parent.width; leftAlign:true; iconText:"󰈔"; text:"Send files"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.selectFiles() }
-          Button { width:parent.width; leftAlign:true; iconText:"󰅇"; text:"Send clipboard"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=1}}; onClicked:root.sendClipboard() }
-          Button { width:parent.width; leftAlign:true; bordered:false; iconText:"󰅁"; text:"Back"; foreground:root.dim; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===2; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=2}}; onClicked:root.goBack() }
+          Button { width:parent.width; leftAlign:true; iconText:"󰈔"; text:"Send files"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){root.noteHover(v,0)}; onClicked:root.selectFiles() }
+          Button { width:parent.width; leftAlign:true; iconText:"󰅇"; text:"Send clipboard"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){root.noteHover(v,1)}; onClicked:root.sendClipboard() }
+          Button { width:parent.width; leftAlign:true; bordered:false; iconText:"󰅁"; text:"Back"; foreground:root.dim; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===2; onHovered:function(v){root.noteHover(v,2)}; onClicked:root.goBack() }
         }
 
         Column {
@@ -325,12 +343,12 @@ Panel {
 
         Column {
           visible: root.viewState === "incoming_pin_settings"; width:parent.width; spacing:Style.space(8)
-          Button { visible:!root.incomingPinEnabled; width:parent.width; text:"Enable PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.beginIncomingPinEdit() }
+          Button { visible:!root.incomingPinEnabled; width:parent.width; text:"Enable PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){root.noteHover(v,0)}; onClicked:root.beginIncomingPinEdit() }
           Row { visible:root.incomingPinEnabled; width:parent.width; spacing:Style.space(8)
-            Button { width:(parent.width-parent.spacing)/2; text:"Change PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.beginIncomingPinEdit() }
-            Button { width:(parent.width-parent.spacing)/2; text:"Disable PIN"; bordered:true; foreground:root.urgent; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=1}}; onClicked:root.requestDisableIncomingPin() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Change PIN"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){root.noteHover(v,0)}; onClicked:root.beginIncomingPinEdit() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Disable PIN"; bordered:true; foreground:root.urgent; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){root.noteHover(v,1)}; onClicked:root.requestDisableIncomingPin() }
           }
-          Button { width:parent.width; leftAlign:true; bordered:false; iconText:"󰅁"; text:"Back"; foreground:root.dim; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===(root.incomingPinEnabled?2:1); onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=root.incomingPinEnabled?2:1}}; onClicked:root.goBack() }
+          Button { width:parent.width; leftAlign:true; bordered:false; iconText:"󰅁"; text:"Back"; foreground:root.dim; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===(root.incomingPinEnabled?2:1); onHovered:function(v){root.noteHover(v,root.incomingPinEnabled?2:1)}; onClicked:root.goBack() }
           Text { visible:root.incomingPinError!==""; width:parent.width; text:root.incomingPinError; color:root.urgent; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
         }
 
@@ -357,8 +375,8 @@ Panel {
           Text { width:parent.width; text:"New incoming requests will no longer require a PIN."; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
           Text { visible:root.incomingPinError!==""; width:parent.width; text:root.incomingPinError; color:root.urgent; font.family:root.fontFamily; font.pixelSize:Style.font.body; wrapMode:Text.Wrap }
           Row { width:parent.width; spacing:Style.space(8)
-            Button { width:(parent.width-parent.spacing)/2; text:"Cancel"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.dim; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.cancelIncomingPinSettings() }
-            Button { width:(parent.width-parent.spacing)/2; text:root.incomingPinUpdating?"Disabling…":"Disable"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.urgent; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=1}}; onClicked:root.confirmDisableIncomingPin() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Cancel"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.dim; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){root.noteHover(v,0)}; onClicked:root.cancelIncomingPinSettings() }
+            Button { width:(parent.width-parent.spacing)/2; text:root.incomingPinUpdating?"Disabling…":"Disable"; bordered:true; enabled:!root.incomingPinUpdating; foreground:root.urgent; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){root.noteHover(v,1)}; onClicked:root.confirmDisableIncomingPin() }
           }
         }
 
@@ -368,8 +386,8 @@ Panel {
           Text { width:parent.width; textFormat:Text.PlainText; text:root.incoming ? Model.incomingSummary(root.incoming.files)+" · "+Model.formatBytes(root.incoming.total) : ""; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body; elide:Text.ElideRight }
           Text { visible:root.incomingQueue.length>1; width:parent.width; text:(root.incomingQueue.length-1)+(root.incomingQueue.length===2 ? " more request" : " more requests"); color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body }
           Row { width:parent.width; spacing:Style.space(8)
-            Button { width:(parent.width-parent.spacing)/2; text:"Decline"; foreground:root.urgent; bordered:true; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:root.declineIncoming() }
-            Button { width:(parent.width-parent.spacing)/2; text:"Accept"; foreground:root.foreground; bordered:true; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=1}}; onClicked:root.acceptIncoming() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Decline"; foreground:root.urgent; bordered:true; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){root.noteHover(v,0)}; onClicked:root.declineIncoming() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Accept"; foreground:root.foreground; bordered:true; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){root.noteHover(v,1)}; onClicked:root.acceptIncoming() }
           }
         }
 
@@ -394,8 +412,8 @@ Panel {
           PanelSectionHeader { text:"RECEIVED TEXT"; foreground:root.foreground; fontFamily:root.fontFamily }
           Text { width:parent.width; textFormat:Text.PlainText; text:root.incomingText; wrapMode:Text.Wrap; maximumLineCount:6; elide:Text.ElideRight; color:root.foreground; font.family:root.fontFamily; font.pixelSize:Style.font.body }
           Row { width:parent.width; spacing:Style.space(8)
-            Button { width:(parent.width-parent.spacing)/2; text:"Copy"; iconText:"󰆏"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=0}}; onClicked:{root.copyReceivedText()} }
-            Button { width:(parent.width-parent.spacing)/2; text:"Done"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){if(v){root.cursorActive=true;root.selectedIndex=1}}; onClicked:root.finishText() }
+            Button { width:(parent.width-parent.spacing)/2; text:"Copy"; iconText:"󰆏"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===0; onHovered:function(v){root.noteHover(v,0)}; onClicked:{root.copyReceivedText()} }
+            Button { width:(parent.width-parent.spacing)/2; text:"Done"; bordered:true; foreground:root.foreground; hasCursor:root.cursorActive&&root.selectedIndex===1; onHovered:function(v){root.noteHover(v,1)}; onClicked:root.finishText() }
           }
         }
       }

--- a/Panel.qml
+++ b/Panel.qml
@@ -68,7 +68,10 @@ Panel {
   readonly property string heroMetaText: {
     if (viewState === "nearby") {
       if (!receiverEnabled) return "Turned off"
-      if (!backendReady) return errorText || statusText
+      // statusText, never errorText: this line is uppercased and letterspaced,
+      // so a full sentence crops mid-word and the body below is already saying
+      // the same thing in full.
+      if (!backendReady) return statusText
       return nearbyPhrases[nearbyPhraseIndex % nearbyPhrases.length]
     }
     if (viewState === "incoming_pin_settings") return incomingPinEnabled ? "Protection enabled" : "Protection disabled"

--- a/README.md
+++ b/README.md
@@ -182,16 +182,27 @@ Generated helper binaries are not tracked in the repository.
 
 ## Updates
 
-Prebuilt installations must be updated with Nearby's installer so the plugin and
-helper move to the same release together:
+Prebuilt installations are updated with Nearby's installer, which moves the
+plugin and its helper to the same release together:
 
 ```sh
 ~/.config/omarchy/plugins/oma.nearby/install.sh
 ```
 
-Running `omarchy plugin update oma.nearby` updates source files but cannot update
-the release helper. Nearby detects that version mismatch, stops the backend, and
-asks you to run the installer again.
+`omarchy plugin update oma.nearby` updates source files but cannot update the
+release helper: it fetches and fast-forwards the checkout, and `bin/` is not
+tracked. Nearby therefore states the oldest helper it can drive in
+`manifest.json`:
+
+```json
+"minHelperVersion": "1.1.0"
+```
+
+A helper at or above that version keeps working after a source-only update, so
+a release that does not change what the plugin asks of the helper no longer
+needs the installer run at all. Below it, Nearby stops the backend and reports
+which version it needs and which one is installed. Raise `minHelperVersion` in
+the same change that starts depending on a new helper.
 
 ## Releases
 

--- a/Service.qml
+++ b/Service.qml
@@ -50,6 +50,12 @@ Item {
   readonly property bool receiverEnabled: Model.receiverEnabledIn(configEntry)
 
   property string pluginVersion: ""
+  property string minHelperVersion: ""
+  // The version the helper has to reach. A manifest that does not declare a
+  // floor is read as requiring the version it ships with, which is the rule
+  // this plugin followed before the field existed.
+  readonly property string requiredHelperVersion: minHelperVersion !== "" ? minHelperVersion : pluginVersion
+  property string helperVersion: ""
   property bool backendReady: false
   property bool discoveryActive: false
   property var devices: []
@@ -101,6 +107,7 @@ Item {
     printErrors: false
     onLoaded: {
       root.pluginVersion = Model.manifestVersion(text(), root.manifestPluginId)
+      root.minHelperVersion = Model.manifestMinHelperVersion(text(), root.manifestPluginId)
       if (root.pluginVersion === "") {
         root.errorText = "Nearby manifest version unavailable."
         root.statusText = root.errorText
@@ -108,6 +115,7 @@ Item {
     }
     onLoadFailed: function(error) {
       root.pluginVersion = ""
+      root.minHelperVersion = ""
       root.errorText = "Nearby manifest version unavailable."
       root.statusText = root.errorText
     }
@@ -346,10 +354,13 @@ Item {
       backendStartupFailurePort=Number(event.port) || 0
     }
     else if (event.event === "ready") {
-      if (!Model.helperVersionMatches(pluginVersion, event.helperVersion)) {
+      helperVersion=String(event.helperVersion || "")
+      if (!Model.helperSatisfies(requiredHelperVersion, helperVersion)) {
         backendReady=false
         backendVersionMismatch=true
-        reportFailure("Helper out of date", "Nearby backend version mismatch. Run the Nearby installer again.")
+        reportFailure("Helper out of date",
+          "Nearby needs helper " + requiredHelperVersion + ". Installed: "
+            + (helperVersion !== "" ? helperVersion : "unknown") + ".")
         send({command:"shutdown"})
         return
       }

--- a/Service.qml
+++ b/Service.qml
@@ -229,6 +229,11 @@ Item {
     incomingPinUpdating=true; pendingIncomingPinEnabled=false; incomingPinError=""
     send({command:"disable_incoming_pin"})
   }
+  // The hero gets a short status and the body gets the detail. Assigning one
+  // sentence to both is what cropped it: the hero line is uppercased and
+  // letterspaced, so anything longer than a few words ends in an ellipsis
+  // partway through a word and tells the user less than the icon already did.
+  function reportFailure(summary, detail) { statusText=summary; errorText=detail }
   function failWith(message) { viewState="error"; errorText=message; statusText=errorText }
   function cancelOutgoing() { send({command:"cancel_outgoing",transfer_id:outgoingTransferId}) }
   function noteTextCopied() { if (viewState !== "text") return; viewState="success"; statusText="Received" }
@@ -314,21 +319,22 @@ Item {
       // other pre-ready failures remain generic. Both keep the existing
       // bounded retry schedule so a transient conflict can recover.
       if (backendStartupFailureCode === "receiver_security_settings_invalid") {
-        errorText = "Nearby security settings are invalid. Repair or remove Nearby's settings.json in your XDG state directory."
+        reportFailure("Security settings invalid",
+          "Nearby security settings are invalid. Repair or remove Nearby's settings.json in your XDG state directory.")
       } else if (backendRestart.attempts < 4) {
-        errorText = "Nearby receiver could not start. Retrying…"
+        reportFailure("Retrying…", "Nearby receiver could not start. Retrying…")
       } else if (backendStartupFailureCode === "receiver_port_in_use") {
         var port = backendStartupFailurePort > 0 ? backendStartupFailurePort : 53317
-        errorText = "LocalSend receiver port " + port + " is already in use. Another LocalSend receiver on this computer may be running. Quit it and enable Nearby again."
+        reportFailure("Port " + port + " in use",
+          "LocalSend receiver port " + port + " is already in use. Another LocalSend receiver on this computer may be running. Quit it and enable Nearby again.")
       } else {
-        errorText = "Nearby receiver could not start."
+        reportFailure("Could not start", "Nearby receiver could not start.")
       }
-      statusText=errorText
     } else {
-      errorText=code===0 ? "Receiver stopped" : "Receiver unavailable"
-      statusText=errorText
-      if (viewState.indexOf("incoming_pin_")===0) { viewState="error"; errorText="Nearby backend stopped while updating receiver security"; statusText=errorText }
-      else if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; errorText="Nearby backend stopped during transfer"; statusText=errorText }
+      reportFailure(code===0 ? "Receiver stopped" : "Receiver unavailable",
+        code===0 ? "Receiver stopped" : "Receiver unavailable")
+      if (viewState.indexOf("incoming_pin_")===0) { viewState="error"; reportFailure("Backend stopped", "Nearby backend stopped while updating receiver security") }
+      else if (viewState==="sending"||viewState==="receiving"||viewState==="pin"||viewState==="incoming") { viewState="error"; reportFailure("Backend stopped", "Nearby backend stopped during transfer") }
     }
     if (backendStartupFailureCode !== "receiver_security_settings_invalid" && backendRestart.attempts < 4) { backendRestart.attempts++; backendRestart.interval=Math.min(30000,1000*Math.pow(2,backendRestart.attempts-1)); backendRestart.restart() }
   }
@@ -343,8 +349,7 @@ Item {
       if (!Model.helperVersionMatches(pluginVersion, event.helperVersion)) {
         backendReady=false
         backendVersionMismatch=true
-        errorText="Nearby backend version mismatch. Run the Nearby installer again."
-        statusText=errorText
+        reportFailure("Helper out of date", "Nearby backend version mismatch. Run the Nearby installer again.")
         send({command:"shutdown"})
         return
       }
@@ -427,8 +432,8 @@ Item {
       // running counts as one that failed to launch.
       if (!root.receiverEnabled || root.pluginVersion === "") return
       root.backendReady=false
-      root.errorText="Nearby helper is missing. Run the Nearby installer again or build it with ./build.sh."
-      root.statusText=root.errorText
+      root.reportFailure("Helper missing",
+        "Nearby helper is missing. Run the Nearby installer again or build it with ./build.sh.")
     }
     onExited: function(code) { root.handleBackendExit(code) }
   }

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "omarchy-nearby-helper"
-version = "1.1.0"
+version = "1.1.1-dev"
 dependencies = [
  "anyhow",
  "localsend-rs",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omarchy-nearby-helper"
-version = "1.1.0"
+version = "1.1.1-dev"
 edition = "2024"
 license = "MIT"
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "id": "oma.nearby",
   "name": "Nearby",
   "version": "1.1.0",
+  "minHelperVersion": "1.1.0",
   "author": "jfg96",
   "description": "Native nearby sharing compatible with the LocalSend protocol",
   "kinds": [

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "oma.nearby",
   "name": "Nearby",
-  "version": "1.1.0",
+  "version": "1.1.1-dev",
   "author": "jfg96",
   "description": "Native nearby sharing compatible with the LocalSend protocol",
   "kinds": [

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -37,6 +37,43 @@ assert.equal(Model.manifestVersion('{"id":"oma.nearby","version":"1.0.2"}', "oma
 assert.equal(Model.manifestVersion('{"id":"other.plugin","version":"1.0.2"}', "oma.nearby"), "")
 assert.equal(Model.manifestVersion('{"id":"oma.nearby"}', "oma.nearby"), "")
 assert.equal(Model.manifestVersion("not json", "oma.nearby"), "")
+// SemVer precedence, including the rule the release process depends on: a
+// prerelease sorts below the release it leads up to, so a checkout on 1.1.0-dev
+// is not satisfied by the 1.1.0 floor it is heading for and 1.1.0 is not held
+// back by a 1.1.0-dev helper.
+assert.equal(Model.compareVersions("1.0.0", "1.0.0"), 0)
+assert.equal(Model.compareVersions("1.2.0", "1.10.0"), -1)
+assert.equal(Model.compareVersions("2.0.0", "1.99.99"), 1)
+assert.equal(Model.compareVersions("1.1.0-dev", "1.1.0"), -1)
+assert.equal(Model.compareVersions("1.1.0", "1.1.0-dev"), 1)
+assert.equal(Model.compareVersions("1.1.0-dev.2", "1.1.0-dev.10"), -1)
+assert.equal(Model.compareVersions("1.1.0-alpha", "1.1.0-beta"), -1)
+assert.equal(Model.compareVersions("1.1.0-1", "1.1.0-alpha"), -1)
+assert.equal(Model.compareVersions("1.0", "1.0.0"), null, "an unreadable version is unknown, not equal")
+assert.equal(Model.compareVersions("", "1.0.0"), null)
+
+// The floor is what a source-only `omarchy plugin update` has to survive: the
+// checkout moves ahead of the helper, and a helper that still speaks the same
+// commands must keep working instead of stopping the plugin dead.
+assert.equal(Model.helperSatisfies("1.0.6", "1.0.6"), true)
+assert.equal(Model.helperSatisfies("1.0.6", "1.0.7"), true, "a helper past the floor is still usable")
+assert.equal(Model.helperSatisfies("1.0.6", "1.0.5"), false)
+assert.equal(Model.helperSatisfies("1.1.0", "1.1.0-dev"), false, "a prerelease is below the release")
+assert.equal(Model.helperSatisfies("1.0.6", ""), false, "no version reported is not a version that passes")
+assert.equal(Model.helperSatisfies("", "1.0.6"), false, "no floor known is not a floor that passes")
+
+// Behind the shipped version but above the floor: offer the update, do not
+// stop for it.
+assert.equal(Model.helperUpdateAvailable("1.1.0", "1.0.7"), true)
+assert.equal(Model.helperUpdateAvailable("1.1.0", "1.1.0"), false)
+assert.equal(Model.helperUpdateAvailable("1.1.0", "1.2.0"), false)
+assert.equal(Model.helperUpdateAvailable("1.1.0", ""), false)
+
+assert.equal(Model.manifestMinHelperVersion('{"id":"oma.nearby","version":"1.1.0","minHelperVersion":"1.0.6"}', "oma.nearby"), "1.0.6")
+assert.equal(Model.manifestMinHelperVersion('{"id":"oma.nearby","version":"1.1.0"}', "oma.nearby"), "",
+  "a manifest without the field declares no floor, and the service falls back to its own version")
+assert.equal(Model.manifestMinHelperVersion('{"id":"other.plugin","minHelperVersion":"1.0.6"}', "oma.nearby"), "")
+assert.equal(Model.manifestMinHelperVersion("not json", "oma.nearby"), "")
 // The service reads its own entry out of shell.json. An absent entry is a
 // config that has not been applied yet, which is why it is null rather than an
 // empty settings object: the receiver stays off until the entry is seen, so a

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -63,6 +63,13 @@ assert.match(source, /command:\s*\["omarchy-file-select"/,
   "the file chooser must be omarchy-file-select")
 assert.equal(/code\s*===?\s*127/.test(source), false,
   "no shell runs on our behalf, so a missing command never reports exit code 127")
+
+// The hero is uppercased and letterspaced, so it takes the short status the
+// engine sets and never the full error sentence, which cropped mid-word.
+assert.match(source, /if \(!backendReady\) return statusText/,
+  "the hero must show the short status")
+assert.equal(source.includes("return errorText || statusText"), false,
+  "falling back to the long error text is what put a cropped sentence in the hero")
 for (const launcher of ["picker", "clipboard", "clipboardWriter"]) {
   assert.match(source, new RegExp(`onRunningChanged:\\s*if\\s*\\(!running && !${launcher}\\.launched`),
     `${launcher} must report a command that never launched, which Quickshell signals by ` +

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -70,6 +70,14 @@ assert.match(source, /if \(!backendReady\) return statusText/,
   "the hero must show the short status")
 assert.equal(source.includes("return errorText || statusText"), false,
   "falling back to the long error text is what put a cropped sentence in the hero")
+
+// Every hover handler goes through noteHover. The originals only handled
+// enter, so hasCursor stayed on the last button the pointer crossed.
+assert.equal((source.match(/onHovered/g) || []).length,
+  (source.match(/root\.noteHover\(/g) || []).length,
+  "a hover handler that does not release the cursor leaves the button lit after the pointer goes")
+assert.doesNotMatch(source, /onHovered[^\n]*if\s*\(v\)\s*\{\s*root\.cursorActive=true/,
+  "taking the cursor on enter without releasing it on leave is the bug this replaced")
 for (const launcher of ["picker", "clipboard", "clipboardWriter"]) {
   assert.match(source, new RegExp(`onRunningChanged:\\s*if\\s*\\(!running && !${launcher}\\.launched`),
     `${launcher} must report a command that never launched, which Quickshell signals by ` +
@@ -118,6 +126,7 @@ const functionNames = [
   "cancelIncomingPinSettings", "submitIncomingPin", "confirmDisableIncomingPin",
   "clearSecretInputs",
   "goBack", "selectFiles", "sendClipboard", "copyReceivedText", "moveCursor", "activateCursor",
+  "noteHover",
 ]
 
 // Every call the view makes has to land on the shared engine, so the stub
@@ -208,6 +217,47 @@ function callNames(state) {
   state.activateCursor()
   assert.equal(callNames(state).at(-1), "openIncomingPinSettings",
     "the entry after rescan opens incoming PIN settings")
+}
+
+// Leaving a button must put its highlight out, and moving between two must
+// leave exactly one lit whichever order the enter and the leave arrive in.
+{
+  const state = panel({viewState: "nearby", devices: [{alias: "A"}, {alias: "B"}], selectedIndex: -1})
+  state.noteHover(true, 0)
+  assert.equal(state.cursorActive, true)
+  assert.equal(state.selectedIndex, 0)
+
+  state.noteHover(false, 0)
+  assert.equal(state.cursorActive, false, "the pointer left, so nothing may still look hovered")
+  assert.equal(state.selectedIndex, 0, "the index survives so an arrow key resumes from here")
+
+  state.noteHover(true, 0)
+  state.noteHover(false, 0)
+  state.noteHover(true, 1)
+  assert.equal(state.cursorActive, true)
+  assert.equal(state.selectedIndex, 1)
+
+  // Enter on the next button before leave on the previous one: the stale
+  // leave must not put out the button the pointer is now on.
+  state.noteHover(true, 0)
+  state.noteHover(true, 1)
+  state.noteHover(false, 0)
+  assert.equal(state.cursorActive, true, "a late leave from the previous button must not clear the new one")
+  assert.equal(state.selectedIndex, 1)
+
+  assert.equal(state.engine.calls.length, 0, "hovering is local to one monitor")
+}
+
+// A released cursor comes back on the first arrow key, from where the mouse
+// left it rather than from the top of the list.
+{
+  const state = panel({viewState: "nearby", devices: [{alias: "A"}, {alias: "B"}], selectedIndex: 0})
+  state.noteHover(true, 1)
+  state.noteHover(false, 1)
+  assert.equal(state.cursorActive, false)
+  state.moveCursor(0, 1)
+  assert.equal(state.cursorActive, true)
+  assert.equal(state.selectedIndex, 2, "the keyboard resumes from the button the pointer last touched")
 }
 
 {

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -39,6 +39,8 @@ assert.match(source, /id: backendRestart[\s\S]*?onTriggered:[^\n]*bindBackendRun
   "the retry timer must restore the Process.running binding")
 assert.doesNotMatch(source, /backend\.running\s*=\s*true/,
   "a plain retry assignment would permanently remove the Process.running binding")
+assert.match(source, /Model\.helperSatisfies\(requiredHelperVersion, helperVersion\)/,
+  "the helper is checked against the floor the manifest declares, not against an exact version")
 
 function extractFunction(name) {
   const marker = `function ${name}`
@@ -74,6 +76,19 @@ function backendEligible(state) {
   assert.match(expression, /receiverConfigured/,
     "eligibility must depend on having read the config, not only on the receiver switch")
   return vm.runInNewContext(`(${expression})`, {root: state})
+}
+
+// The version floor is a binding, not a function, so it comes out of the
+// source rather than being restated. A manifest with no floor falls back to
+// the version it ships with, and a test that hardcoded that fallback would not
+// notice it changing under the check that depends on it.
+function requiredHelperVersion(state) {
+  const match = source.match(/readonly property string requiredHelperVersion:\s*([^\n]+)/)
+  assert.notEqual(match, null, "Service.qml must derive the helper version floor")
+  return vm.runInNewContext(`(${match[1].trim()})`, {
+    minHelperVersion: state.minHelperVersion,
+    pluginVersion: state.pluginVersion,
+  })
 }
 
 const functionNames = [
@@ -116,6 +131,8 @@ function engine(initial = {}) {
     anyViewOpen: true,
     shutdownPending: false,
     pluginVersion: "1.0.4",
+    minHelperVersion: "",
+    helperVersion: "",
     backendVersionMismatch: false,
     backendStartupFailureCode: "",
     backendStartupFailurePort: 0,
@@ -147,6 +164,10 @@ function engine(initial = {}) {
     ...initial,
   }
   Object.defineProperty(context, "incoming", {get() { return Model.currentIncoming(context.incomingQueue) }})
+  Object.defineProperty(context, "requiredHelperVersion", {
+    enumerable: true,
+    get() { return requiredHelperVersion(context) },
+  })
   vm.createContext(context)
   vm.runInContext(functionNames.map(extractFunction).join("\n"), context)
   context.sent = sent
@@ -209,7 +230,7 @@ function engine(initial = {}) {
   const state = engine({pluginVersion: "1.1.0", backendReady: false, viewState: "nearby"})
   state.handleEvent({event: "ready", helperVersion: "1.0.7"})
   assert.equal(state.statusText, "Helper out of date")
-  assert.match(state.errorText, /Run the Nearby installer again/)
+  assert.match(state.errorText, /Nearby needs helper/)
   assert.notEqual(state.statusText, state.errorText)
 }
 
@@ -230,6 +251,61 @@ for (const [name, setup] of [
   state.handleBackendExit(1)
   assert.ok(state.statusText.length <= 26,
     `${name} label must fit the hero, got ${state.statusText.length} characters: ${state.statusText}`)
+}
+
+// `omarchy plugin update` fast-forwards the checkout and cannot move the
+// helper: bin/ is not tracked and Omarchy runs no plugin script on update. So
+// the plugin routinely runs one version ahead of its helper, and requiring an
+// exact match stopped it dead on every release, including releases whose
+// helper it could still drive. The floor is what the helper has to clear.
+{
+  const state = engine({
+    pluginVersion: "1.1.0", minHelperVersion: "1.0.6", backendReady: false, viewState: "nearby",
+  })
+  state.handleEvent({event: "ready", helperVersion: "1.0.7"})
+  assert.equal(state.backendVersionMismatch, false)
+  assert.equal(state.backendReady, true, "a helper above the floor must survive a source-only update")
+  assert.equal(state.sent.some(command => command.command === "shutdown"), false)
+}
+
+// Below the floor is still a stop, and the message names both versions:
+// "run the installer again" never said what was actually wrong.
+{
+  const state = engine({
+    pluginVersion: "1.1.0", minHelperVersion: "1.1.0", backendReady: false, viewState: "nearby",
+  })
+  state.handleEvent({event: "ready", helperVersion: "1.0.7"})
+  assert.equal(state.backendVersionMismatch, true)
+  assert.equal(state.backendReady, false)
+  assert.deepEqual(state.sent.at(-1), {command: "shutdown"})
+  assert.match(state.errorText, /1\.1\.0/)
+  assert.match(state.errorText, /1\.0\.7/)
+}
+
+// No floor declared reads as the shipped version, which is the rule the plugin
+// followed before the field existed.
+{
+  const state = engine({pluginVersion: "1.1.0", minHelperVersion: "", backendReady: false})
+  assert.equal(state.requiredHelperVersion, "1.1.0")
+  state.handleEvent({event: "ready", helperVersion: "1.0.7"})
+  assert.equal(state.backendVersionMismatch, true)
+}
+
+// A helper that reports nothing readable is not one to trust with a transfer.
+{
+  const state = engine({pluginVersion: "1.1.0", minHelperVersion: "1.0.6", backendReady: false})
+  state.handleEvent({event: "ready", helperVersion: ""})
+  assert.equal(state.backendVersionMismatch, true)
+}
+
+// A helper ahead of the plugin is not a reason to refuse to start.
+{
+  const state = engine({
+    pluginVersion: "1.1.0", minHelperVersion: "1.1.0", backendReady: false, viewState: "nearby",
+  })
+  state.handleEvent({event: "ready", helperVersion: "1.2.0"})
+  assert.equal(state.backendVersionMismatch, false)
+  assert.equal(state.backendReady, true)
 }
 
 function incoming(requestId, sender = requestId) {

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -86,7 +86,7 @@ const functionNames = [
   "clearPendingOutgoing", "dispatchPendingOutgoing", "beginOutgoing", "retryWithPin",
   "showPinPrompt", "cancelPin", "acceptIncoming", "declineIncoming",
   "finishIncoming", "finishOutgoing", "finishText", "finishTerminal",
-  "handleBackendExit", "handleEvent",
+  "handleBackendExit", "handleEvent", "reportFailure",
 ]
 
 function engine(initial = {}) {
@@ -169,6 +169,67 @@ function engine(initial = {}) {
   state.receiverEnabled = true
   assert.equal(state.backend.running.callback(), true,
     "the restored binding must make OFF -> ON eligible to start again")
+}
+
+// The hero renders statusText uppercased and letterspaced, and every failure
+// path assigned the same sentence to statusText and errorText. A sentence does
+// not fit there: it was cropped mid-word, so the one line the user saw first
+// said less than the icon beside it. The label and the detail are now separate
+// strings, and the hero takes the label.
+{
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 4, interval: 0, restart: () => {}, stop: () => {}},
+    backendStartupFailureCode: "receiver_port_in_use", backendStartupFailurePort: 53317,
+    backend: {running: false, write: () => {}},
+  })
+  state.root = state
+  state.handleBackendExit(1)
+  assert.equal(state.statusText, "Port 53317 in use")
+  assert.match(state.errorText, /Another LocalSend receiver/,
+    "the body keeps the advice the label has no room for")
+  assert.notEqual(state.statusText, state.errorText)
+}
+
+{
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 4, interval: 0, restart: () => {}, stop: () => {}},
+    backendStartupFailureCode: "receiver_security_settings_invalid",
+    backend: {running: false, write: () => {}},
+  })
+  state.root = state
+  state.handleBackendExit(1)
+  assert.equal(state.statusText, "Security settings invalid")
+  assert.match(state.errorText, /settings\.json/)
+  assert.notEqual(state.statusText, state.errorText)
+}
+
+{
+  const state = engine({pluginVersion: "1.1.0", backendReady: false, viewState: "nearby"})
+  state.handleEvent({event: "ready", helperVersion: "1.0.7"})
+  assert.equal(state.statusText, "Helper out of date")
+  assert.match(state.errorText, /Run the Nearby installer again/)
+  assert.notEqual(state.statusText, state.errorText)
+}
+
+// Whatever a failure path sets, the label has to survive the hero's transform.
+// Twenty-four characters is what the popup fits at its default width.
+for (const [name, setup] of [
+  ["port conflict", {backendStartupFailureCode: "receiver_port_in_use", backendStartupFailurePort: 53317}],
+  ["invalid settings", {backendStartupFailureCode: "receiver_security_settings_invalid"}],
+  ["generic startup failure", {backendStartupFailureCode: ""}],
+]) {
+  const state = engine({
+    backendAcceptedThisRun: false,
+    backendRestart: {attempts: 4, interval: 0, restart: () => {}, stop: () => {}},
+    backend: {running: false, write: () => {}},
+    ...setup,
+  })
+  state.root = state
+  state.handleBackendExit(1)
+  assert.ok(state.statusText.length <= 26,
+    `${name} label must fit the hero, got ${state.statusText.length} characters: ${state.statusText}`)
 }
 
 function incoming(requestId, sender = requestId) {


### PR DESCRIPTION
Refs #7. Third of a stacked series of four.

**Builds on #8 and #9.** The new commit here is `feat: require a minimum helper version instead of an exact one`; the two below it are those PRs and shrink out of this diff as they merge.

This is the change that actually stops #7 recurring, and it is a policy decision, so it is worth its own discussion.

## Problem

The plugin refuses to start unless the helper reports the exact version in `manifest.json`. That match cannot hold in normal use. `omarchy plugin update` fetches and fast-forwards the checkout and stops there, `bin/` is not tracked, and Omarchy runs no plugin-supplied script on update, so there is no path by which the release helper can arrive with the source. Every release therefore leaves the plugin one version ahead of a helper it is perfectly able to drive, and stops it dead.

## Change

Declare the oldest helper the plugin can drive:

```json
"minHelperVersion": "1.1.0"
```

and accept any helper at or above it, by SemVer precedence. A manifest without the field falls back to the version it ships with, which is the current rule, so this cannot loosen an installation that has not opted in.

The payoff: with the cycle open on `1.1.2-dev` and the floor left at `1.1.0`, a source-only `omarchy plugin update` **keeps working** on the released 1.1.0 helper. The mismatch then only appears when the plugin genuinely started depending on a newer helper — raise the floor in that same change.

A helper below the floor is still a hard stop, and now names which version is needed and which is installed instead of asking for a reinstall without saying why. An unreadable version on either side stays a refusal, and a helper *ahead* of the plugin is accepted rather than treated as a fault.

## Tests

`tests/model.test.js` covers SemVer precedence including prerelease ordering (`1.1.0-dev < 1.1.0`, `-dev.2 < -dev.10`, numeric-before-alphanumeric) and unparseable input returning unknown rather than equal. `tests/service-state.test.js` covers a helper above the floor surviving a source-only update, one below it still stopping with both versions named, an absent floor falling back to the shipped version, an unreadable version, and a helper ahead of the plugin. Fails against the pre-change source.

## Verification

Full suite plus all four cargo checks pass. Smoke-tested on Omarchy: forcing the floor above the installed helper stops the receiver and reports both versions; restoring it brings the receiver back.

## Design note

I considered a `protocolVersion` on the `ready` event instead. A floor is strictly more expressive for the same effort — it lets a change say "I need 1.2.0" without inventing a second version axis — and it needs no backend change at all.