### PR TITLE
feat: update the helper from the panel when the plugin outgrows it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Test frontend model
         run: node tests/model.test.js && node tests/panel-state.test.js && node tests/service-state.test.js
 
+      - name: Test helper updater
+        run: bash tests/updater.test.sh
+
       - name: Check Rust formatting
         run: cargo fmt --manifest-path backend/Cargo.toml --all -- --check
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 # Rust build output
 backend/target/
 
-# Locally built helper
+# Locally built helper. The updater that fetches the release helper is source,
+# not a build product, so it is tracked despite living beside one.
 bin/*
 !bin/.gitkeep
+!bin/nearby-update-helper

--- a/Panel.qml
+++ b/Panel.qml
@@ -49,12 +49,32 @@ Panel {
   readonly property bool incomingPinEnabled: engine ? engine.incomingPinEnabled : false
   readonly property bool incomingPinUpdating: engine ? engine.incomingPinUpdating : false
   readonly property string incomingPinError: engine ? engine.incomingPinError : ""
+  readonly property bool helperUpdateOffered: engine ? engine.helperUpdateOffered : false
+  readonly property bool helperUpdating: engine ? engine.helperUpdating : false
+  readonly property string helperUpdateStatus: engine ? engine.helperUpdateStatus : ""
+  readonly property string helperUpdateError: engine ? engine.helperUpdateError : ""
+  readonly property string helperUpdateDetail: engine ? engine.helperUpdateDetail : ""
+  // An unusable helper takes the whole view over: there are no devices to list
+  // and none are coming, so the section stops calling itself DEVICES.
+  readonly property bool helperBlocksNearby: helperUpdateOffered && !backendReady
+
+  // Shown only when the in-panel update cannot do the job, so the user still
+  // has somewhere to go: the repository and the command that does it by hand.
+  readonly property string repositoryUrl: "https://github.com/jfg96/omarchy-nearby"
+  readonly property string installerCommand: "~/.config/omarchy/plugins/oma.nearby/install.sh"
+
+  // The update row is the last thing in the Nearby view, so it sits after the
+  // devices and after the compact action row when that row is there at all.
+  readonly property int helperUpdateIndex: !helperUpdateOffered
+    ? -1
+    : (receiverEnabled && backendReady ? devices.length + 2 : devices.length)
 
   // Cursor and popup focus are per monitor, so they stay here.
   property int selectedIndex: 0
   property bool cursorActive: false
   property int nearbyPhraseIndex: 0
   property bool viewRegistered: false
+  property string copyNote: ""
 
   readonly property var nearbyPhrases: [
     "Looking nearby",
@@ -125,6 +145,10 @@ Panel {
   function submitIncomingPin() { if (engine) engine.submitIncomingPin(String(incomingPinInput.text || "")) }
   function confirmDisableIncomingPin() { if (engine) engine.confirmDisableIncomingPin() }
   function clearSecretInputs() { pinInput.text = ""; incomingPinInput.text = "" }
+  function updateHelper() { copyNote=""; if (engine) engine.startHelperUpdate() }
+  function copyText(value) { if (textCopier.running) return; copyNote=""; textCopier.payload=String(value); textCopier.launched=false; textCopier.running=true }
+  function copyInstallerCommand() { copyText(installerCommand) }
+  function copyRepositoryLink() { copyText(repositoryUrl) }
   function failWith(message) { if (engine) engine.failWith(message) }
   function noteTextCopied() { if (engine) engine.noteTextCopied() }
   function beginOutgoing(pending) { if (engine) engine.beginOutgoing(pending) }
@@ -157,7 +181,12 @@ Panel {
   function moveCursor(dx, dy) {
     cursorActive = true
     if (viewState === "nearby") {
-      var lastNearbyIndex=receiverEnabled&&backendReady ? devices.length+1 : Math.max(-1,devices.length-1)
+      // The update row, when it is showing, is the last stop in either
+      // direction: without it a panel reporting an unusable helper has nothing
+      // below the receiver switch to reach.
+      var lastNearbyIndex=helperUpdateIndex>=0
+        ? helperUpdateIndex
+        : (receiverEnabled&&backendReady ? devices.length+1 : Math.max(-1,devices.length-1))
       if (dx !== 0 && selectedIndex >= devices.length) {
         selectedIndex = Math.max(devices.length, Math.min(lastNearbyIndex, selectedIndex + dx))
         return
@@ -177,7 +206,15 @@ Panel {
     if (count > 0 && dy !== 0) selectedIndex = Math.max(0, Math.min(count - 1, selectedIndex + dy))
   }
   function activateCursor() {
-    if (viewState === "nearby") selectedIndex < 0 ? toggleReceiver() : (selectedIndex === devices.length ? forceFullDiscovery() : (selectedIndex === devices.length+1 ? openIncomingPinSettings() : chooseDevice(selectedIndex)))
+    if (viewState === "nearby") {
+      // Checked before the action row: with the helper unusable that row is
+      // hidden, and the update button takes the index rescan would have had.
+      if (selectedIndex < 0) toggleReceiver()
+      else if (helperUpdateIndex >= 0 && selectedIndex === helperUpdateIndex) updateHelper()
+      else if (selectedIndex < devices.length) chooseDevice(selectedIndex)
+      else if (receiverEnabled && backendReady && selectedIndex === devices.length) forceFullDiscovery()
+      else if (receiverEnabled && backendReady && selectedIndex === devices.length+1) openIncomingPinSettings()
+    }
     else if (viewState === "target") selectedIndex === 0 ? selectFiles() : (selectedIndex === 1 ? sendClipboard() : goBack())
     else if (viewState === "incoming") selectedIndex === 0 ? declineIncoming() : acceptIncoming()
     else if (viewState === "text") { if(selectedIndex===0)copyReceivedText(); else finishText() }
@@ -304,8 +341,10 @@ Panel {
 
         Column {
           visible: root.viewState === "nearby"; width: parent.width; spacing: Style.space(6)
-          PanelSectionHeader { text: "DEVICES"; foreground:root.foreground; fontFamily:root.fontFamily }
-          Text { visible: root.devices.length===0; width:parent.width; textFormat:Text.PlainText; text: !root.receiverEnabled ? "Nearby is turned off" : (root.discoveryActive ? "Finding devices…" : (root.backendReady ? "No devices nearby" : root.errorText)); wrapMode:Text.Wrap; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body; topPadding:Style.space(12); bottomPadding:Style.space(12) }
+          PanelSectionHeader { text: root.helperBlocksNearby ? "HELPER" : "DEVICES"; foreground:root.foreground; fontFamily:root.fontFamily }
+          // Silent while the helper row owns the view: its text there was
+          // errorText, which the row states once already.
+          Text { visible: root.devices.length===0 && !root.helperBlocksNearby; width:parent.width; textFormat:Text.PlainText; text: !root.receiverEnabled ? "Nearby is turned off" : (root.discoveryActive ? "Finding devices…" : (root.backendReady ? "No devices nearby" : root.errorText)); wrapMode:Text.Wrap; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body; topPadding:Style.space(12); bottomPadding:Style.space(12) }
           Repeater {
             model: root.devices
             Button { required property var modelData; required property int index; width:parent.width; leftAlign:true; bordered:false; iconText:Model.iconFor(modelData.deviceType); text:modelData.alias; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===index; onHovered:function(v){root.noteHover(v,index)}; onClicked:root.chooseDevice(index) }
@@ -314,6 +353,70 @@ Panel {
             id:nearbyActions; visible:root.receiverEnabled&&root.backendReady; width:parent.width; spacing:Style.space(8)
             Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰑐"; text:"Rescan"; tooltipText:"Search for new devices"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length; onHovered:function(v){root.noteHover(v,root.devices.length)}; onClicked:root.forceFullDiscovery() }
             Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰌾"; text:"PIN · "+(root.incomingPinEnabled?"On":"Off"); tooltipText:"Incoming PIN settings"; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.devices.length+1; onHovered:function(v){root.noteHover(v,root.devices.length+1)}; onClicked:root.openIncomingPinSettings() }
+          }
+
+          // `omarchy plugin update` fast-forwards the checkout and stops there.
+          // The helper is a release asset and bin/ is not tracked, so a source
+          // update always leaves the previous binary in place and there is no
+          // hook that could fetch the new one. That gap is closable from here:
+          // the button replaces only the binary, which is the half Omarchy
+          // does not move. The repository and the manual command appear when
+          // it cannot -- no arch build published, no network, a checkout on a
+          // development version that has no release at all.
+          Column {
+            id: helperUpdate
+            visible: root.helperUpdateOffered; width:parent.width; spacing:Style.space(6)
+            // Only when it follows something. With the helper blocking the
+            // view this row is the section, and a rule under its own header
+            // separates nothing.
+            PanelSeparator { visible:!root.helperBlocksNearby; width:parent.width }
+
+            // The versions, once. Replaced by live progress while the updater
+            // runs so the button is not the only thing that moves.
+            Text {
+              width:parent.width; textFormat:Text.PlainText; wrapMode:Text.Wrap
+              text: root.helperUpdating && root.helperUpdateStatus!=="" ? root.helperUpdateStatus : root.helperUpdateDetail
+              color: root.helperUpdating ? root.dim : root.foreground
+              font.family:root.fontFamily; font.pixelSize:Style.font.body
+            }
+            Text {
+              visible:!root.helperUpdating; width:parent.width; textFormat:Text.PlainText; wrapMode:Text.Wrap
+              text:"Updating the plugin cannot replace the helper binary."
+              color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body
+            }
+            Button {
+              width:parent.width; bordered:true
+              iconText: root.helperUpdateError!=="" && !root.helperUpdating ? "󰑐" : "󰇚"
+              // After a failure the old label gives no sign the press landed,
+              // and the error above it stays put; naming the retry is the only
+              // thing that distinguishes "not pressed yet" from "pressed once".
+              text: root.helperUpdating ? "Updating…" : (root.helperUpdateError!=="" ? "Try again" : "Update helper")
+              tooltipText:"Download the helper that matches this version"
+              enabled:!root.helperUpdating
+              foreground:root.foreground; fontFamily:root.fontFamily
+              hasCursor:root.cursorActive&&root.selectedIndex===root.helperUpdateIndex
+              onHovered:function(v){root.noteHover(v,root.helperUpdateIndex)}
+              onClicked:root.updateHelper()
+            }
+
+            // The fallback is subordinate to the failure, so it sits under a
+            // rule of its own rather than continuing the same flat stack.
+            Column {
+              visible:root.helperUpdateError!==""; width:parent.width; spacing:Style.space(6)
+              Text { width:parent.width; textFormat:Text.PlainText; text:root.helperUpdateError; wrapMode:Text.Wrap; color:root.urgent; font.family:root.fontFamily; font.pixelSize:Style.font.body }
+              PanelSeparator { width:parent.width }
+              Text { width:parent.width; textFormat:Text.PlainText; text:"Or run this in a terminal:"; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body }
+              // Elided rather than wrapped: wrapping broke the path across two
+              // lines and orphaned the `.sh`, which reads like a typo and is
+              // one. The full text goes to the clipboard, not to the eye.
+              Text { width:parent.width; textFormat:Text.PlainText; text:root.installerCommand; elide:Text.ElideMiddle; color:root.foreground; font.family:root.fontFamily; font.pixelSize:Style.font.body }
+              Row {
+                width:parent.width; spacing:Style.space(8)
+                Button { width:(parent.width-parent.spacing)/2; bordered:true; iconText:"󰆏"; text:"Copy command"; tooltipText:root.installerCommand; foreground:root.foreground; fontFamily:root.fontFamily; onClicked:root.copyInstallerCommand() }
+                Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰌷"; text:"Copy link"; tooltipText:root.repositoryUrl; foreground:root.dim; fontFamily:root.fontFamily; onClicked:root.copyRepositoryLink() }
+              }
+              Text { visible:root.copyNote!==""; width:parent.width; textFormat:Text.PlainText; text:root.copyNote; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body }
+            }
           }
         }
 
@@ -418,6 +521,20 @@ Panel {
         }
       }
     }
+  }
+
+  // The text goes out as an argument rather than through stdin: none of it is
+  // secret, and it keeps this independent of clipboardWriter, which holds
+  // mid-transfer state the update row must not disturb.
+  Process {
+    id: textCopier
+    property bool launched: false
+    property string payload: ""
+    command: ["wl-copy", textCopier.payload]
+    running: false
+    onStarted: textCopier.launched=true
+    onRunningChanged: if (!running && !textCopier.launched) root.copyNote="wl-copy is required to copy"
+    onExited: function(code) { root.copyNote = code===0 ? "Copied to clipboard" : "wl-copy is required to copy" }
   }
 
   Process {

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ bin/omarchy-nearby-helper
 ```
 
 Generated helper binaries are not tracked in the repository.
+`bin/nearby-update-helper` is source rather than a build product, so it is
+tracked despite living beside one.
 
 ## Updates
 
@@ -203,6 +205,22 @@ a release that does not change what the plugin asks of the helper no longer
 needs the installer run at all. Below it, Nearby stops the backend and reports
 which version it needs and which one is installed. Raise `minHelperVersion` in
 the same change that starts depending on a new helper.
+
+When the helper does need replacing, the Nearby panel offers to do it. The
+Update helper button fetches the release helper matching `manifest.json`,
+checks it against the release SHA256, replaces `bin/omarchy-nearby-helper` and
+restarts the receiver. The same repair is available without the popup:
+
+```sh
+omarchy-shell oma.nearby updateHelper
+omarchy-shell oma.nearby status
+```
+
+That path replaces only the binary. `install.sh` also moves the git checkout
+and refuses to run against a plugin directory with local changes, so it stays
+the way to move plugin and helper to a release together, and the panel falls
+back to it whenever the fetch cannot succeed: no published helper for the
+architecture, no network, or a development checkout with no release at all.
 
 ## Releases
 

--- a/Service.qml
+++ b/Service.qml
@@ -86,6 +86,34 @@ Item {
   property string backendStartupFailureCode: ""
   property int backendStartupFailurePort: 0
 
+  // The helper is the one part of the plugin `omarchy plugin update` cannot
+  // move: bin/ is not tracked, so a source update always leaves the previous
+  // binary behind. All three states below are fixed by fetching the release
+  // helper for the version now on disk, so the panel offers that one action
+  // rather than sending the user to a terminal.
+  property bool helperMissing: false
+  property bool helperUpdating: false
+  property bool helperUpdateInstalled: false
+  property string helperUpdateStatus: ""
+  property string helperUpdateError: ""
+  // Behind but still usable: the version floor accepts it, so this is a nudge
+  // rather than a stop.
+  readonly property bool helperOutdated: helperVersion !== "" && pluginVersion !== ""
+    && Model.helperUpdateAvailable(pluginVersion, helperVersion)
+  readonly property bool helperUpdateOffered: pluginVersion !== ""
+    && (backendVersionMismatch || helperMissing || helperOutdated)
+  // One line, and the only place the versions are stated. The hero shows the
+  // short status and the panel shows this; saying it in both is what made the
+  // popup repeat itself three times over four lines.
+  readonly property string helperUpdateDetail: !helperUpdateOffered
+    ? ""
+    : (helperMissing
+      ? "The helper binary is missing."
+      : (backendVersionMismatch
+        ? "Needs helper " + requiredHelperVersion + " · installed "
+          + (helperVersion !== "" ? helperVersion : "unknown")
+        : "Helper " + helperVersion + " is behind plugin " + pluginVersion + "."))
+
   // Discovery follows the popup, and the popup exists once per monitor, so
   // openness is a count rather than a flag: discovery runs while any view is
   // open and stops when the last one closes.
@@ -141,7 +169,13 @@ Item {
     function receiverOn(): string { if (!root.receiverEnabled) root.toggleReceiver(); return "ok" }
     function receiverOff(): string { if (root.receiverEnabled) root.toggleReceiver(); return "ok" }
     function receiverToggle(): string { root.toggleReceiver(); return "ok" }
-    function status(): string { return JSON.stringify({enabled:root.receiverEnabled,ready:root.backendReady,running:backend.running,devices:root.devices.length}) }
+    // The same repair the panel button runs, for a shell whose bar is not
+    // where the user is looking when the helper stops matching.
+    function updateHelper(): string { if (root.helperUpdating) return "busy"; root.startHelperUpdate(); return "ok" }
+    // The helper version and the floor it has to clear are reported here
+    // because a mismatch otherwise shows up only as a panel that says it is
+    // not ready, which is the same thing a port conflict looks like.
+    function status(): string { return JSON.stringify({enabled:root.receiverEnabled,ready:root.backendReady,running:backend.running,devices:root.devices.length,helper:root.helperVersion,requires:root.requiredHelperVersion,updateOffered:root.helperUpdateOffered}) }
   }
 
   function viewOpened() {
@@ -236,6 +270,53 @@ Item {
     if(incomingPinUpdating||!backendReady||!incomingPinEnabled)return
     incomingPinUpdating=true; pendingIncomingPinEnabled=false; incomingPinError=""
     send({command:"disable_incoming_pin"})
+  }
+  // Fetching the release helper is a separate job from moving the checkout,
+  // and install.sh does both. install.sh also refuses to run against a plugin
+  // directory with local changes, so it cannot be what a button calls. The
+  // updater below only replaces bin/omarchy-nearby-helper, and git already
+  // ignores that path.
+  function startHelperUpdate() {
+    if (helperUpdating || pluginVersion === "" || helperUpdater.running) return
+    helperUpdateError=""
+    helperUpdateStatus="Contacting GitHub…"
+    helperUpdateInstalled=false
+    helperUpdating=true
+    helperUpdater.launched=false
+    helperUpdater.running=true
+  }
+  function handleUpdaterEvent(event) {
+    if (!event || !event.event) return
+    if (event.event === "step") helperUpdateStatus=String(event.message || "")
+    else if (event.event === "done") { helperUpdateStatus=""; helperUpdateError=""; helperUpdateInstalled=true }
+    else if (event.event === "failed") { helperUpdateStatus=""; helperUpdateError=String(event.message || "") }
+  }
+  function finishHelperUpdate(code) {
+    helperUpdating=false
+    helperUpdateStatus=""
+    // The binary landing is what makes the update real, and the updater says
+    // so before it exits. Its exit status can still be lost: replacing the
+    // helper changes the plugin directory, the shell watches that directory
+    // and reloads the plugin, and the reload kills whatever the old service
+    // had running -- including the updater, one line after its work was done.
+    if (code !== 0 && !helperUpdateInstalled) {
+      if (helperUpdateError === "") helperUpdateError="Nearby could not update the helper."
+      return
+    }
+    helperUpdateError=""
+    helperMissing=false
+    helperVersion=""
+    backendVersionMismatch=false
+    backendStartupFailureCode=""
+    backendStartupFailurePort=0
+    backendRestart.stop()
+    backendRestart.attempts=0
+    errorText=""
+    statusText="Starting receiver…"
+    // The mismatch shutdown left Process.running written rather than bound, so
+    // the binding has to be restored before the new helper can start. Same
+    // reason backendRestart calls this instead of assigning true.
+    if (!backend.running) bindBackendRunning()
   }
   // The hero gets a short status and the body gets the detail. Assigning one
   // sentence to both is what cropped it: the hero line is uppercased and
@@ -355,12 +436,11 @@ Item {
     }
     else if (event.event === "ready") {
       helperVersion=String(event.helperVersion || "")
+      helperMissing=false
       if (!Model.helperSatisfies(requiredHelperVersion, helperVersion)) {
         backendReady=false
         backendVersionMismatch=true
-        reportFailure("Helper out of date",
-          "Nearby needs helper " + requiredHelperVersion + ". Installed: "
-            + (helperVersion !== "" ? helperVersion : "unknown") + ".")
+        reportFailure("Helper out of date", helperUpdateDetail)
         send({command:"shutdown"})
         return
       }
@@ -428,6 +508,7 @@ Item {
       backend.launched=true
       root.backendAcceptedThisRun=false
       root.backendVersionMismatch=false
+      root.helperMissing=false
       root.backendStartupFailureCode=""
       root.backendStartupFailurePort=0
     }
@@ -443,10 +524,29 @@ Item {
       // running counts as one that failed to launch.
       if (!root.receiverEnabled || root.pluginVersion === "") return
       root.backendReady=false
+      root.helperMissing=true
       root.reportFailure("Helper missing",
         "Nearby helper is missing. Run the Nearby installer again or build it with ./build.sh.")
     }
     onExited: function(code) { root.handleBackendExit(code) }
+  }
+  Process {
+    id: helperUpdater
+    property bool launched: false
+    command: [root.pluginDir + "/bin/nearby-update-helper"]
+    running: false
+    stdout: SplitParser { onRead: function(line) { root.handleUpdaterEvent(Model.parseLine(line)) } }
+    stderr: SplitParser { onRead: function(line) { console.warn("nearby updater", line) } }
+    onStarted: helperUpdater.launched=true
+    // Same missing-command signal the helper and the file chooser use: no exit
+    // code ever arrives, so the absent updater has to be caught here.
+    onRunningChanged: {
+      if (running || helperUpdater.launched) return
+      root.helperUpdating=false
+      root.helperUpdateStatus=""
+      root.helperUpdateError="The Nearby updater is missing. Reinstall Nearby with install.sh."
+    }
+    onExited: function(code) { root.finishHelperUpdate(code) }
   }
   Timer { id: backendRestart; property int attempts: 0; interval: 1000; repeat: false; onTriggered: if (root.receiverEnabled && !backend.running) root.bindBackendRunning() }
   Timer { id: receiverShutdownFallback; interval: 250; repeat: false; onTriggered: root.finishReceiverShutdown() }

--- a/bin/nearby-update-helper
+++ b/bin/nearby-update-helper
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+# Fetch the release helper that matches this checkout's manifest version.
+#
+# Deliberately not install.sh. That script owns the git checkout as well, and
+# refuses to run when the plugin directory has local changes, so it cannot be
+# the thing a panel button calls. `omarchy plugin update` already moves the
+# source: it fetches, fast-forwards, validates and rescans, and the only thing
+# it cannot move is this binary, because bin/ is not tracked. Keeping the two
+# jobs apart leaves the git side to Omarchy and the binary side here.
+#
+# Progress is reported as one JSON object per line on stdout, the same shape
+# the helper itself uses, so Service.qml can parse it with Model.parseLine:
+#
+#   {"event":"step","message":"…"}   work in progress
+#   {"event":"done","version":"…"}   the binary on disk now matches
+#   {"event":"failed","message":"…"} nothing was replaced
+#
+# Exit status is 0 only after a verified binary has been moved into place.
+
+set -uo pipefail
+
+plugin_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly plugin_dir
+readonly repository="jfg96/omarchy-nearby"
+
+emit() { jq -nc "$@" 2>/dev/null || printf '{"event":"failed","message":"could not report progress"}\n'; }
+step() { emit --arg m "$1" '{event:"step",message:$m}'; }
+fail() {
+  emit --arg m "$1" '{event:"failed",message:$m}'
+  exit 1
+}
+
+# jq builds every line above, so a missing jq cannot be reported as JSON.
+for command_name in curl jq sha256sum; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    printf '{"event":"failed","message":"required command not found: %s"}\n' "$command_name"
+    exit 1
+  fi
+done
+
+case "$(uname -m)" in
+x86_64 | amd64) platform="linux-x86_64" ;;
+*) fail "No prebuilt helper is published for $(uname -m). Build it with ./build.sh." ;;
+esac
+
+manifest="$plugin_dir/manifest.json"
+[[ -f $manifest ]] || fail "manifest.json is missing from $plugin_dir"
+version=$(jq -r '.version // empty' "$manifest") || fail "manifest.json is not valid JSON"
+[[ -n $version ]] || fail "manifest.json does not declare a version"
+
+# Releases exist only for stable tags. A checkout sitting on a prerelease has
+# no published binary at all, so say that rather than reporting a 404 from the
+# release lookup as though the network were at fault.
+[[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+  || fail "Nearby $version is a development build with no published helper. Build it with ./build.sh."
+
+tag="v$version"
+
+# Staged outside the plugin directory, and deliberately so. The shell watches
+# the plugin tree and reloads the plugin when anything in it changes, which
+# tears down the service that owns this process and kills it: downloading nine
+# megabytes into bin/ triggered that reload partway through and left a half
+# staged directory behind every time. Nothing may be written under the plugin
+# until the binary is ready to be its final self.
+#
+# The cache lives on the same filesystem as the config directory on any normal
+# XDG layout, so the last step is still a rename rather than a copy, and the
+# single change the watcher sees is a helper that is already verified.
+mkdir -p "$plugin_dir/bin" || fail "Could not write to $plugin_dir/bin"
+cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/omarchy-nearby"
+mkdir -p "$cache_root" || fail "Could not write to $cache_root"
+stage_dir=$(mktemp -d "$cache_root/update.XXXXXX") || fail "Could not create a staging directory"
+cleanup() { rm -rf -- "$stage_dir"; }
+trap cleanup EXIT
+
+# "Could not reach GitHub" and "GitHub has no such release" are different
+# problems with different fixes, and `curl --fail` reports both as a non-zero
+# exit. Telling someone to check their connection when the connection is fine
+# and the release simply does not exist sends them to fix the one thing that is
+# not broken, so the transport failure and the HTTP status are read separately.
+step "Looking up Nearby $tag…"
+release_file="$stage_dir/release.json"
+http_status=$(curl --location --silent --output "$release_file" --write-out '%{http_code}' \
+  "https://api.github.com/repos/${repository}/releases/tags/${tag}")
+curl_status=$?
+(( curl_status == 0 )) \
+  || fail "Could not reach GitHub (curl error $curl_status). Check your connection and try again."
+
+case "$http_status" in
+200) ;;
+404) fail "GitHub has no release $tag. Nearby $version may not be published yet." ;;
+403 | 429) fail "GitHub is rate-limiting this update. Try again in a few minutes." ;;
+5??) fail "GitHub is having trouble (HTTP $http_status). Try again shortly." ;;
+*) fail "GitHub returned HTTP $http_status for release $tag." ;;
+esac
+
+release_json=$(<"$release_file")
+jq -e '.draft == false' >/dev/null 2>&1 <<<"$release_json" || fail "Release $tag is a draft"
+jq -e '.prerelease == false' >/dev/null 2>&1 <<<"$release_json" || fail "Release $tag is a prerelease"
+
+asset_name="omarchy-nearby-helper-${tag}-${platform}"
+checksum_name="${asset_name}.sha256"
+asset_url=$(jq -r --arg name "$asset_name" \
+  '.assets[]? | select(.name == $name) | .browser_download_url' <<<"$release_json")
+checksum_url=$(jq -r --arg name "$checksum_name" \
+  '.assets[]? | select(.name == $name) | .browser_download_url' <<<"$release_json")
+[[ -n $asset_url && -n $checksum_url ]] \
+  || fail "Release $tag publishes no $platform helper. Build it with ./build.sh."
+
+step "Downloading helper $tag…"
+curl --fail --location --silent --show-error --output "$stage_dir/$asset_name" "$asset_url" \
+  || fail "The $tag helper download did not finish. Check your connection and try again."
+curl --fail --location --silent --show-error --output "$stage_dir/$checksum_name" "$checksum_url" \
+  || fail "The $tag checksum download did not finish. Check your connection and try again."
+
+step "Verifying checksum…"
+(cd "$stage_dir" && sha256sum --check --strict "$checksum_name" >/dev/null 2>&1) \
+  || fail "The downloaded helper failed its SHA256 check and was discarded"
+
+chmod 0755 "$stage_dir/$asset_name" || fail "Could not make the helper executable"
+
+# Replacing the entry rather than the file: a helper still running keeps the
+# inode it was started from and exits on its own.
+mv -- "$stage_dir/$asset_name" "$plugin_dir/bin/omarchy-nearby-helper" \
+  || fail "Could not install the helper into $plugin_dir/bin"
+
+emit --arg v "$version" '{event:"done",version:$v}'
+
+# Last, because it writes into the watched tree: an earlier version of this
+# script staged in bin/, and every run the reload killed left its directory
+# behind. Anything that interrupts the sweep now costs nothing.
+for orphan in "$plugin_dir"/bin/.update.*; do
+  if [[ -d $orphan ]]; then rm -rf -- "$orphan"; fi
+done
+
+# The sweep must not decide the exit status: with nothing to sweep the glob
+# stays literal, the test fails, and a successful update reported failure.
+exit 0

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -37,6 +37,7 @@ assert.equal(Model.manifestVersion('{"id":"oma.nearby","version":"1.0.2"}', "oma
 assert.equal(Model.manifestVersion('{"id":"other.plugin","version":"1.0.2"}', "oma.nearby"), "")
 assert.equal(Model.manifestVersion('{"id":"oma.nearby"}', "oma.nearby"), "")
 assert.equal(Model.manifestVersion("not json", "oma.nearby"), "")
+
 // SemVer precedence, including the rule the release process depends on: a
 // prerelease sorts below the release it leads up to, so a checkout on 1.1.0-dev
 // is not satisfied by the 1.1.0 floor it is heading for and 1.1.0 is not held

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -63,22 +63,54 @@ assert.match(source, /command:\s*\["omarchy-file-select"/,
   "the file chooser must be omarchy-file-select")
 assert.equal(/code\s*===?\s*127/.test(source), false,
   "no shell runs on our behalf, so a missing command never reports exit code 127")
+// The update row exists because `omarchy plugin update` cannot replace the
+// helper: bin/ is not tracked and Omarchy runs no plugin script on update. The
+// panel must therefore offer the action itself, and must keep the repository
+// and the manual command for the cases the action cannot cover.
+assert.match(source, /id: helperUpdate[\s\S]*?visible: root\.helperUpdateOffered/,
+  "the update row must appear exactly when the engine says the helper needs one")
+assert.match(source, /text: root\.helperUpdating \? "Updating…" : \(root\.helperUpdateError!=="" \? "Try again" : "Update helper"\)/,
+  "the button must name the retry after a failure, and say it is working while it works")
+assert.match(source, /enabled:!root\.helperUpdating/,
+  "a second press while the updater runs must not start a second download")
+assert.match(source, /visible:root\.helperUpdateError!==""[\s\S]*?root\.installerCommand[\s\S]*?onClicked:root\.copyInstallerCommand\(\)[\s\S]*?onClicked:root\.copyRepositoryLink\(\)/,
+  "a failed update must offer the command that fixes it, not only the repository link")
+assert.match(source, /readonly property string repositoryUrl: "https:\/\/github\.com\/jfg96\/omarchy-nearby"/,
+  "the fallback link must point at the repository the installer pulls from")
+assert.equal(source.includes("install.sh\"]"), false,
+  "install.sh owns the checkout and refuses a dirty one, so the panel must not call it")
 
-// The hero is uppercased and letterspaced, so it takes the short status the
-// engine sets and never the full error sentence, which cropped mid-word.
+// The popup used to say the same thing three times: the hero, the device
+// empty-state line, and the update row all rendered the version mismatch, and
+// the hero cropped its copy mid-word.
 assert.match(source, /if \(!backendReady\) return statusText/,
-  "the hero must show the short status")
+  "the hero must show the short status, not the full error sentence")
 assert.equal(source.includes("return errorText || statusText"), false,
-  "falling back to the long error text is what put a cropped sentence in the hero")
+  "the hero must not fall back to the long error text")
+assert.match(source, /text: root\.helperBlocksNearby \? "HELPER" : "DEVICES"/,
+  "a view owned by the helper failure must not head its section DEVICES")
+assert.match(source, /visible: root\.devices\.length===0 && !root\.helperBlocksNearby/,
+  "the device empty-state line must not repeat the error the update row states")
+assert.equal((source.match(/root\.helperUpdateDetail/g) || []).length, 1,
+  "the versions belong in one place: the engine's detail line, rendered once")
 
-// Every hover handler goes through noteHover. The originals only handled
-// enter, so hasCursor stayed on the last button the pointer crossed.
+// The path is 48 characters in a 360-wide popup. Wrapping it split the
+// extension onto its own line, which reads as a typo and invites one.
+assert.match(source, /text:root\.installerCommand; elide:Text\.ElideMiddle/,
+  "the installer path must elide rather than wrap")
+assert.doesNotMatch(source, /text:root\.installerCommand[^\n]*WrapAnywhere/,
+  "wrapping the path anywhere is what orphaned the .sh")
+
+// Every hover handler must go through noteHover. The originals only handled
+// enter, so `hasCursor` stayed on the last button the pointer crossed and the
+// popup showed a highlight the mouse had already left.
 assert.equal((source.match(/onHovered/g) || []).length,
   (source.match(/root\.noteHover\(/g) || []).length,
   "a hover handler that does not release the cursor leaves the button lit after the pointer goes")
 assert.doesNotMatch(source, /onHovered[^\n]*if\s*\(v\)\s*\{\s*root\.cursorActive=true/,
   "taking the cursor on enter without releasing it on leave is the bug this replaced")
-for (const launcher of ["picker", "clipboard", "clipboardWriter"]) {
+
+for (const launcher of ["picker", "clipboard", "clipboardWriter", "textCopier"]) {
   assert.match(source, new RegExp(`onRunningChanged:\\s*if\\s*\\(!running && !${launcher}\\.launched`),
     `${launcher} must report a command that never launched, which Quickshell signals by ` +
     "returning running to false without an exit code")
@@ -126,7 +158,7 @@ const functionNames = [
   "cancelIncomingPinSettings", "submitIncomingPin", "confirmDisableIncomingPin",
   "clearSecretInputs",
   "goBack", "selectFiles", "sendClipboard", "copyReceivedText", "moveCursor", "activateCursor",
-  "noteHover",
+  "updateHelper", "copyText", "copyInstallerCommand", "copyRepositoryLink", "noteHover",
 ]
 
 // Every call the view makes has to land on the shared engine, so the stub
@@ -157,9 +189,20 @@ function stubEngine() {
     failWith: record("failWith"),
     noteTextCopied: record("noteTextCopied"),
     beginOutgoing: record("beginOutgoing"),
+    startHelperUpdate: record("startHelperUpdate"),
     viewOpened: record("viewOpened"),
     viewClosed: record("viewClosed"),
   }
+}
+
+// The row index of the update button is a binding, not a function, so it is
+// pulled out of the source and evaluated rather than restated here: a copy of
+// the expression could not catch it drifting away from the order the panel
+// actually draws, which is the whole point of asserting on it.
+function helperUpdateIndexExpression() {
+  const match = source.match(/readonly property int helperUpdateIndex:\s*([\s\S]*?)\n\s*\n/)
+  assert.notEqual(match, null, "Panel.qml must bind helperUpdateIndex")
+  return match[1].trim()
 }
 
 function panel(initial = {}) {
@@ -172,6 +215,9 @@ function panel(initial = {}) {
     picker: {running: false, launched: false},
     clipboard: {running: false, launched: false},
     clipboardWriter: {running: false, launched: false},
+    textCopier: {running: false, launched: false, payload: ""},
+    copyNote: "",
+    helperUpdateOffered: false,
     pinInput: {text: "", forceActiveFocus: () => {}},
     incomingPinInput: {text: "", forceActiveFocus: () => {}},
     keyCatcher: {forceActiveFocus: () => {}},
@@ -191,6 +237,16 @@ function panel(initial = {}) {
     ...initial,
   }
   context.engine = engine
+  const indexExpression = helperUpdateIndexExpression()
+  Object.defineProperty(context, "helperUpdateIndex", {
+    enumerable: true,
+    get: () => vm.runInNewContext(`(${indexExpression})`, {
+      helperUpdateOffered: context.helperUpdateOffered,
+      receiverEnabled: context.receiverEnabled,
+      backendReady: context.backendReady,
+      devices: context.devices,
+    }),
+  })
   vm.createContext(context)
   vm.runInContext(functionNames.map(extractFunction).join("\n"), context)
   context.closes = closes
@@ -219,8 +275,40 @@ function callNames(state) {
     "the entry after rescan opens incoming PIN settings")
 }
 
-// Leaving a button must put its highlight out, and moving between two must
-// leave exactly one lit whichever order the enter and the leave arrive in.
+// An unusable helper hides the action row, so the update button takes the
+// index rescan would have had. Keyboard users have to be able to reach it:
+// without it the only stop below the receiver switch is nothing at all.
+{
+  const state = panel({
+    viewState: "nearby", devices: [], backendReady: false, helperUpdateOffered: true, selectedIndex: -1,
+  })
+  assert.equal(state.helperUpdateIndex, 0)
+  state.moveCursor(0, 1)
+  assert.equal(state.selectedIndex, 0, "the cursor must reach the update button with no devices listed")
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "startHelperUpdate",
+    "the keyboard must trigger the same update the button does")
+  state.moveCursor(0, 3)
+  assert.equal(state.selectedIndex, 0, "the update button is the last stop in the Nearby view")
+}
+
+// Usable but behind: the action row is still drawn, so the update button lands
+// after it rather than on top of rescan.
+{
+  const state = panel({
+    viewState: "nearby", devices: [{alias: "A"}], backendReady: true, helperUpdateOffered: true, selectedIndex: 1,
+  })
+  assert.equal(state.helperUpdateIndex, 3)
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "forceFullDiscovery",
+    "an offered update must not displace rescan while the helper still works")
+  state.selectedIndex = 3
+  state.activateCursor()
+  assert.equal(callNames(state).at(-1), "startHelperUpdate")
+}
+
+// Leaving a button must put the highlight out, and moving between two must
+// leave exactly one lit whichever order the enter and leave arrive in.
 {
   const state = panel({viewState: "nearby", devices: [{alias: "A"}, {alias: "B"}], selectedIndex: -1})
   state.noteHover(true, 0)
@@ -231,14 +319,15 @@ function callNames(state) {
   assert.equal(state.cursorActive, false, "the pointer left, so nothing may still look hovered")
   assert.equal(state.selectedIndex, 0, "the index survives so an arrow key resumes from here")
 
+  // leave-then-enter
   state.noteHover(true, 0)
   state.noteHover(false, 0)
   state.noteHover(true, 1)
   assert.equal(state.cursorActive, true)
   assert.equal(state.selectedIndex, 1)
 
-  // Enter on the next button before leave on the previous one: the stale
-  // leave must not put out the button the pointer is now on.
+  // enter-then-leave: the stale leave must not put out the button the pointer
+  // is now on.
   state.noteHover(true, 0)
   state.noteHover(true, 1)
   state.noteHover(false, 0)
@@ -258,6 +347,14 @@ function callNames(state) {
   state.moveCursor(0, 1)
   assert.equal(state.cursorActive, true)
   assert.equal(state.selectedIndex, 2, "the keyboard resumes from the button the pointer last touched")
+}
+
+// No update offered: the Nearby view keeps the row order it had.
+{
+  const state = panel({viewState: "nearby", devices: [{alias: "A"}], selectedIndex: 0})
+  assert.equal(state.helperUpdateIndex, -1)
+  state.moveCursor(0, 9)
+  assert.equal(state.selectedIndex, 2, "the cursor still stops on incoming PIN settings")
 }
 
 {

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -39,6 +39,21 @@ assert.match(source, /id: backendRestart[\s\S]*?onTriggered:[^\n]*bindBackendRun
   "the retry timer must restore the Process.running binding")
 assert.doesNotMatch(source, /backend\.running\s*=\s*true/,
   "a plain retry assignment would permanently remove the Process.running binding")
+
+// `omarchy plugin update` fetches, fast-forwards, validates and rescans, and
+// runs nothing the plugin ships. bin/ is not tracked, so the release helper
+// cannot arrive that way and there is no hook that could fetch it. The plugin
+// closes that gap itself, with a script that touches only the binary:
+// install.sh also owns the checkout and refuses a plugin directory with local
+// changes, so it cannot be what the panel calls.
+assert.match(source, /command:\s*\[root\.pluginDir \+ "\/bin\/nearby-update-helper"\]/,
+  "the in-panel update must run the binary-only updater")
+assert.doesNotMatch(source, /install\.sh"\]/,
+  "install.sh owns the git checkout and declines a dirty one; the panel must not call it")
+assert.match(source, /id: helperUpdater[\s\S]*?onRunningChanged:\s*\{\s*\n\s*if \(running \|\| helperUpdater\.launched\) return/,
+  "an updater that never launched must be reported the same way a missing helper is")
+assert.match(source, /function finishHelperUpdate[\s\S]*?if \(!backend\.running\) bindBackendRunning\(\)/,
+  "a successful update must restore the Process.running binding the mismatch shutdown wrote over")
 assert.match(source, /Model\.helperSatisfies\(requiredHelperVersion, helperVersion\)/,
   "the helper is checked against the floor the manifest declares, not against an exact version")
 
@@ -78,10 +93,10 @@ function backendEligible(state) {
   return vm.runInNewContext(`(${expression})`, {root: state})
 }
 
-// The version floor is a binding, not a function, so it comes out of the
-// source rather than being restated. A manifest with no floor falls back to
-// the version it ships with, and a test that hardcoded that fallback would not
-// notice it changing under the check that depends on it.
+// The version floor is a binding too, so it comes out of the source rather
+// than being restated. A manifest with no floor falls back to the version it
+// ships with, and a test that hardcoded that fallback would not notice it
+// changing under the check that depends on it.
 function requiredHelperVersion(state) {
   const match = source.match(/readonly property string requiredHelperVersion:\s*([^\n]+)/)
   assert.notEqual(match, null, "Service.qml must derive the helper version floor")
@@ -89,6 +104,33 @@ function requiredHelperVersion(state) {
     minHelperVersion: state.minHelperVersion,
     pluginVersion: state.pluginVersion,
   })
+}
+
+// What the panel offers is a chain of derived bindings, and each one is pulled
+// out of the source rather than restated here: they decide whether the update
+// row appears and what it says, so a copy could agree with the test while
+// disagreeing with the plugin.
+function extractBinding(name) {
+  const match = source.match(new RegExp(
+    `readonly property \\w+ ${name}:\\s*([\\s\\S]*?)(?=\\n\\s*(?://|readonly property|property |function |[A-Z]\\w*\\s*\\{))`))
+  assert.notEqual(match, null, `Service.qml must bind ${name}`)
+  return match[1].trim()
+}
+
+function helperDerived(state) {
+  const scope = {
+    Model,
+    helperVersion: state.helperVersion,
+    pluginVersion: state.pluginVersion,
+    minHelperVersion: state.minHelperVersion,
+    helperMissing: state.helperMissing,
+    backendVersionMismatch: state.backendVersionMismatch,
+    requiredHelperVersion: requiredHelperVersion(state),
+  }
+  for (const name of ["helperOutdated", "helperUpdateOffered", "helperUpdateDetail"]) {
+    scope[name] = vm.runInNewContext(`(${extractBinding(name)})`, scope)
+  }
+  return scope
 }
 
 const functionNames = [
@@ -101,7 +143,8 @@ const functionNames = [
   "clearPendingOutgoing", "dispatchPendingOutgoing", "beginOutgoing", "retryWithPin",
   "showPinPrompt", "cancelPin", "acceptIncoming", "declineIncoming",
   "finishIncoming", "finishOutgoing", "finishText", "finishTerminal",
-  "handleBackendExit", "handleEvent", "reportFailure",
+  "handleBackendExit", "handleEvent",
+  "reportFailure", "startHelperUpdate", "handleUpdaterEvent", "finishHelperUpdate",
 ]
 
 function engine(initial = {}) {
@@ -133,6 +176,12 @@ function engine(initial = {}) {
     pluginVersion: "1.0.4",
     minHelperVersion: "",
     helperVersion: "",
+    helperMissing: false,
+    helperUpdating: false,
+    helperUpdateInstalled: false,
+    helperUpdateStatus: "",
+    helperUpdateError: "",
+    helperUpdater: {running: false, launched: false},
     backendVersionMismatch: false,
     backendStartupFailureCode: "",
     backendStartupFailurePort: 0,
@@ -168,6 +217,12 @@ function engine(initial = {}) {
     enumerable: true,
     get() { return requiredHelperVersion(context) },
   })
+  for (const derived of ["helperOutdated", "helperUpdateOffered", "helperUpdateDetail"]) {
+    Object.defineProperty(context, derived, {
+      enumerable: true,
+      get() { return helperDerived(context)[derived] },
+    })
+  }
   vm.createContext(context)
   vm.runInContext(functionNames.map(extractFunction).join("\n"), context)
   context.sent = sent
@@ -192,50 +247,43 @@ function engine(initial = {}) {
     "the restored binding must make OFF -> ON eligible to start again")
 }
 
-// The hero renders statusText uppercased and letterspaced, and every failure
-// path assigned the same sentence to statusText and errorText. A sentence does
-// not fit there: it was cropped mid-word, so the one line the user saw first
-// said less than the icon beside it. The label and the detail are now separate
-// strings, and the hero takes the label.
+// A source-only update moves the plugin ahead of a helper that can still be
+// driven. That used to stop the plugin dead on every release; the floor is
+// what keeps a compatible helper working.
 {
   const state = engine({
-    backendAcceptedThisRun: false,
-    backendRestart: {attempts: 4, interval: 0, restart: () => {}, stop: () => {}},
-    backendStartupFailureCode: "receiver_port_in_use", backendStartupFailurePort: 53317,
-    backend: {running: false, write: () => {}},
+    pluginVersion: "1.1.0", minHelperVersion: "1.0.6", backendReady: false, viewState: "nearby",
   })
-  state.root = state
-  state.handleBackendExit(1)
-  assert.equal(state.statusText, "Port 53317 in use")
-  assert.match(state.errorText, /Another LocalSend receiver/,
-    "the body keeps the advice the label has no room for")
-  assert.notEqual(state.statusText, state.errorText)
-}
-
-{
-  const state = engine({
-    backendAcceptedThisRun: false,
-    backendRestart: {attempts: 4, interval: 0, restart: () => {}, stop: () => {}},
-    backendStartupFailureCode: "receiver_security_settings_invalid",
-    backend: {running: false, write: () => {}},
-  })
-  state.root = state
-  state.handleBackendExit(1)
-  assert.equal(state.statusText, "Security settings invalid")
-  assert.match(state.errorText, /settings\.json/)
-  assert.notEqual(state.statusText, state.errorText)
-}
-
-{
-  const state = engine({pluginVersion: "1.1.0", backendReady: false, viewState: "nearby"})
   state.handleEvent({event: "ready", helperVersion: "1.0.7"})
+  assert.equal(state.backendVersionMismatch, false)
+  assert.equal(state.backendReady, true, "a helper above the floor must keep working after a source update")
+  assert.equal(state.sent.some(command => command.command === "shutdown"), false)
+}
+
+// Below the floor is still a stop, and the message has to name both versions:
+// "run the installer again" was the old text and it did not say what was wrong.
+//
+// The hero renders statusText uppercased and letterspaced, so it gets a label
+// and the body gets the sentence. Assigning the sentence to both is what made
+// the popup print the same text twice, once cropped mid-word.
+{
+  const state = engine({
+    pluginVersion: "1.1.0", minHelperVersion: "1.1.0", backendReady: false, viewState: "nearby",
+  })
+  state.handleEvent({event: "ready", helperVersion: "1.0.7"})
+  assert.equal(state.backendVersionMismatch, true)
+  assert.equal(state.backendReady, false)
+  assert.deepEqual(state.sent.at(-1), {command: "shutdown"})
+  assert.match(state.errorText, /1\.1\.0/)
+  assert.match(state.errorText, /1\.0\.7/)
   assert.equal(state.statusText, "Helper out of date")
-  assert.match(state.errorText, /Nearby needs helper/)
-  assert.notEqual(state.statusText, state.errorText)
+  assert.notEqual(state.statusText, state.errorText,
+    "the hero label and the body detail must not be the same string")
+  assert.ok(state.statusText.length <= 24,
+    `the hero label must fit uppercased and letterspaced, got ${state.statusText.length} characters`)
 }
 
 // Whatever a failure path sets, the label has to survive the hero's transform.
-// Twenty-four characters is what the popup fits at its default width.
 for (const [name, setup] of [
   ["port conflict", {backendStartupFailureCode: "receiver_port_in_use", backendStartupFailurePort: 53317}],
   ["invalid settings", {backendStartupFailureCode: "receiver_security_settings_invalid"}],
@@ -253,33 +301,47 @@ for (const [name, setup] of [
     `${name} label must fit the hero, got ${state.statusText.length} characters: ${state.statusText}`)
 }
 
-// `omarchy plugin update` fast-forwards the checkout and cannot move the
-// helper: bin/ is not tracked and Omarchy runs no plugin script on update. So
-// the plugin routinely runs one version ahead of its helper, and requiring an
-// exact match stopped it dead on every release, including releases whose
-// helper it could still drive. The floor is what the helper has to clear.
+// Same rule for the other failures that reach the hero. The port conflict was
+// the worst of them: 150 characters of advice cropped down to a fragment.
 {
   const state = engine({
-    pluginVersion: "1.1.0", minHelperVersion: "1.0.6", backendReady: false, viewState: "nearby",
+    backendAcceptedThisRun: false, backendRestart: {attempts: 4, interval: 0, restart: () => {}, stop: () => {}},
+    backendStartupFailureCode: "receiver_port_in_use", backendStartupFailurePort: 53317,
+    backend: {running: false, write: () => {}},
   })
-  state.handleEvent({event: "ready", helperVersion: "1.0.7"})
-  assert.equal(state.backendVersionMismatch, false)
-  assert.equal(state.backendReady, true, "a helper above the floor must survive a source-only update")
-  assert.equal(state.sent.some(command => command.command === "shutdown"), false)
+  state.root = state
+  state.handleBackendExit(1)
+  assert.equal(state.statusText, "Port 53317 in use")
+  assert.match(state.errorText, /Another LocalSend receiver/)
+  assert.notEqual(state.statusText, state.errorText)
 }
 
-// Below the floor is still a stop, and the message names both versions:
-// "run the installer again" never said what was actually wrong.
 {
   const state = engine({
-    pluginVersion: "1.1.0", minHelperVersion: "1.1.0", backendReady: false, viewState: "nearby",
+    backendAcceptedThisRun: false, backendRestart: {attempts: 4, interval: 0, restart: () => {}, stop: () => {}},
+    backendStartupFailureCode: "receiver_security_settings_invalid",
+    backend: {running: false, write: () => {}},
   })
-  state.handleEvent({event: "ready", helperVersion: "1.0.7"})
-  assert.equal(state.backendVersionMismatch, true)
-  assert.equal(state.backendReady, false)
-  assert.deepEqual(state.sent.at(-1), {command: "shutdown"})
-  assert.match(state.errorText, /1\.1\.0/)
-  assert.match(state.errorText, /1\.0\.7/)
+  state.root = state
+  state.handleBackendExit(1)
+  assert.equal(state.statusText, "Security settings invalid")
+  assert.match(state.errorText, /settings\.json/)
+}
+
+// The detail line is the only place the versions are stated, so the panel can
+// drop the copies it used to print above and below it.
+{
+  const state = engine({pluginVersion: "1.1.0", minHelperVersion: "1.1.0", helperVersion: "1.0.7", backendVersionMismatch: true})
+  assert.equal(state.helperUpdateDetail, "Needs helper 1.1.0 · installed 1.0.7")
+}
+{
+  const state = engine({pluginVersion: "1.1.0", helperMissing: true})
+  assert.equal(state.helperUpdateDetail, "The helper binary is missing.")
+}
+{
+  const state = engine({pluginVersion: "1.1.0", minHelperVersion: "1.0.0", helperVersion: "1.0.7"})
+  assert.equal(state.helperUpdateOffered, true, "a helper above the floor but behind the plugin is still worth updating")
+  assert.match(state.helperUpdateDetail, /behind plugin 1\.1\.0/)
 }
 
 // No floor declared reads as the shipped version, which is the rule the plugin
@@ -291,13 +353,6 @@ for (const [name, setup] of [
   assert.equal(state.backendVersionMismatch, true)
 }
 
-// A helper that reports nothing readable is not one to trust with a transfer.
-{
-  const state = engine({pluginVersion: "1.1.0", minHelperVersion: "1.0.6", backendReady: false})
-  state.handleEvent({event: "ready", helperVersion: ""})
-  assert.equal(state.backendVersionMismatch, true)
-}
-
 // A helper ahead of the plugin is not a reason to refuse to start.
 {
   const state = engine({
@@ -306,6 +361,87 @@ for (const [name, setup] of [
   state.handleEvent({event: "ready", helperVersion: "1.2.0"})
   assert.equal(state.backendVersionMismatch, false)
   assert.equal(state.backendReady, true)
+}
+
+// A helper that reports nothing readable is not one to trust with a transfer.
+{
+  const state = engine({pluginVersion: "1.1.0", minHelperVersion: "1.0.6", backendReady: false})
+  state.handleEvent({event: "ready", helperVersion: ""})
+  assert.equal(state.backendVersionMismatch, true)
+}
+
+{
+  const state = engine({
+    pluginVersion: "1.1.0", minHelperVersion: "1.1.0", backendReady: false,
+    backendVersionMismatch: true, errorText: "Nearby needs helper 1.1.0. Installed: 1.0.7.",
+    backend: {running: false, write: () => {}},
+  })
+  state.root = state
+
+  state.startHelperUpdate()
+  assert.equal(state.helperUpdating, true)
+  assert.equal(state.helperUpdater.running, true)
+  state.startHelperUpdate()
+  assert.equal(state.helperUpdater.launched, false,
+    "a second press while the updater runs must not start another download")
+
+  state.handleUpdaterEvent({event: "step", message: "Downloading helper v1.1.0…"})
+  assert.equal(state.helperUpdateStatus, "Downloading helper v1.1.0…")
+
+  state.handleUpdaterEvent({event: "done", version: "1.1.0"})
+  state.finishHelperUpdate(0)
+  assert.equal(state.helperUpdating, false)
+  assert.equal(state.backendVersionMismatch, false)
+  assert.equal(state.helperUpdateError, "")
+  assert.equal(state.errorText, "")
+  assert.equal(typeof state.backend.running.callback, "function",
+    "the restored binding is what starts the helper the update just installed")
+  assert.equal(state.backend.running.callback(), true)
+}
+
+// A failed update leaves the old binary in place, so the plugin must stay in
+// the state that says so rather than pretending the helper is new.
+{
+  const state = engine({
+    pluginVersion: "1.1.0", minHelperVersion: "1.1.0", backendReady: false,
+    backendVersionMismatch: true, backend: {running: false, write: () => {}},
+  })
+  state.root = state
+  state.startHelperUpdate()
+  state.handleUpdaterEvent({event: "failed", message: "Download of the v1.1.0 helper failed"})
+  state.finishHelperUpdate(1)
+  assert.equal(state.helperUpdating, false)
+  assert.equal(state.helperUpdateError, "Download of the v1.1.0 helper failed")
+  assert.equal(state.backendVersionMismatch, true)
+  assert.equal(state.backend.running, false, "a failed update must not try to start the old helper again")
+}
+
+// Installing the helper changes the plugin directory, the shell watches that
+// directory, and the reload it triggers kills the updater a line after its
+// work is done. The exit status is lost; the binary is not. Reporting a
+// failure there would send the user back to a terminal to redo an update that
+// already succeeded.
+{
+  const state = engine({
+    pluginVersion: "1.1.0", minHelperVersion: "1.1.0", backendReady: false,
+    backendVersionMismatch: true, backend: {running: false, write: () => {}},
+  })
+  state.root = state
+  state.startHelperUpdate()
+  state.handleUpdaterEvent({event: "done", version: "1.1.0"})
+  state.finishHelperUpdate(143)
+  assert.equal(state.helperUpdateError, "")
+  assert.equal(state.backendVersionMismatch, false)
+  assert.equal(typeof state.backend.running.callback, "function")
+}
+
+// An updater that dies without reporting anything still has to say something.
+{
+  const state = engine({pluginVersion: "1.1.0", backend: {running: false, write: () => {}}})
+  state.root = state
+  state.startHelperUpdate()
+  state.finishHelperUpdate(1)
+  assert.equal(state.helperUpdateError, "Nearby could not update the helper.")
 }
 
 function incoming(requestId, sender = requestId) {

--- a/tests/updater.test.sh
+++ b/tests/updater.test.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+
+# bin/nearby-update-helper, offline.
+#
+# The updater is the part of this plugin that reaches the network, verifies a
+# checksum and replaces a running binary, and every bug that reached a user so
+# far lived in it: a 404 reported as a dead connection, nine megabytes staged
+# inside the watched plugin directory, and a sweep loop that returned 1 from a
+# successful run. None of that is reachable from the QML tests, so it is
+# covered here with a curl stub on PATH -- the script needs no seam of its own.
+#
+# Run: bash tests/updater.test.sh
+
+set -uo pipefail
+
+tests_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly updater_source="$tests_dir/../bin/nearby-update-helper"
+[[ -f $updater_source ]] || { echo "updater not found: $updater_source" >&2; exit 1; }
+
+failures=0
+current=""
+
+announce() { current="$1"; }
+report() {
+  echo "  FAIL: $current" >&2
+  echo "        $1" >&2
+  failures=$((failures + 1))
+}
+assert_eq() {
+  [[ $1 == "$2" ]] || report "expected '$2', got '$1'${3:+ ($3)}"
+}
+assert_contains() {
+  [[ $1 == *"$2"* ]] || report "expected output to contain '$2', got: $1"
+}
+assert_not_contains() {
+  [[ $1 != *"$2"* ]] || report "expected output NOT to contain '$2', got: $1"
+}
+
+# A sandbox per case: a plugin directory holding only what the updater reads,
+# a cache root for its staging, and a stub curl ahead of the real one.
+setup() {
+  sandbox=$(mktemp -d "${TMPDIR:-/tmp}/nearby-updater-test.XXXXXX")
+  plugin="$sandbox/plugin"
+  stub_bin="$sandbox/stub-bin"
+  mkdir -p "$plugin/bin" "$stub_bin" "$sandbox/cache" "$sandbox/served"
+  cp "$updater_source" "$plugin/bin/nearby-update-helper"
+  chmod 0755 "$plugin/bin/nearby-update-helper"
+  printf 'old helper\n' >"$plugin/bin/omarchy-nearby-helper"
+  chmod 0755 "$plugin/bin/omarchy-nearby-helper"
+  manifest "1.1.0"
+
+  # The stub answers the three calls the updater makes, told apart by URL, and
+  # is steered entirely by environment so each case stays declarative.
+  cat >"$stub_bin/curl" <<'STUB'
+#!/usr/bin/env bash
+output=""
+url=""
+previous=""
+for argument in "$@"; do
+  case "$previous" in
+  --output) output="$argument" ;;
+  esac
+  case "$argument" in
+  http*) url="$argument" ;;
+  esac
+  previous="$argument"
+done
+
+if [[ $url == *api.github.com* ]]; then
+  (( ${FAKE_LOOKUP_EXIT:-0} == 0 )) || exit "$FAKE_LOOKUP_EXIT"
+  [[ -n $output ]] && cp "${FAKE_RELEASE_JSON:-/dev/null}" "$output"
+  printf '%s' "${FAKE_HTTP_STATUS:-200}"
+  exit 0
+fi
+
+if [[ $url == *.sha256 ]]; then
+  (( ${FAKE_CHECKSUM_EXIT:-0} == 0 )) || exit "$FAKE_CHECKSUM_EXIT"
+  cp "$FAKE_CHECKSUM_FILE" "$output"
+  exit 0
+fi
+
+sleep "${FAKE_ASSET_DELAY:-0}"
+(( ${FAKE_ASSET_EXIT:-0} == 0 )) || exit "$FAKE_ASSET_EXIT"
+cp "$FAKE_ASSET_FILE" "$output"
+exit 0
+STUB
+  chmod 0755 "$stub_bin/curl"
+
+  platform="linux-$(uname -m)"
+  [[ $platform == "linux-amd64" ]] && platform="linux-x86_64"
+  asset_name="omarchy-nearby-helper-v1.1.0-${platform}"
+
+  printf 'new helper 1.1.0\n' >"$sandbox/served/$asset_name"
+  ( cd "$sandbox/served" && sha256sum "$asset_name" >"$asset_name.sha256" )
+
+  export FAKE_RELEASE_JSON="$sandbox/release.json"
+  export FAKE_ASSET_FILE="$sandbox/served/$asset_name"
+  export FAKE_CHECKSUM_FILE="$sandbox/served/$asset_name.sha256"
+  release_json "$asset_name" false false
+}
+
+teardown() {
+  [[ -n ${sandbox:-} && -d $sandbox ]] && rm -rf -- "$sandbox"
+  unset FAKE_RELEASE_JSON FAKE_ASSET_FILE FAKE_CHECKSUM_FILE
+  unset FAKE_HTTP_STATUS FAKE_LOOKUP_EXIT FAKE_ASSET_EXIT FAKE_CHECKSUM_EXIT FAKE_ASSET_DELAY
+}
+
+manifest() {
+  printf '{"id":"oma.nearby","version":"%s","minHelperVersion":"%s"}\n' "$1" "$1" >"$plugin/manifest.json"
+}
+
+release_json() {
+  jq -n --arg name "$1" --argjson draft "$2" --argjson prerelease "$3" '{
+    tag_name: "v1.1.0", draft: $draft, prerelease: $prerelease,
+    assets: [
+      {name: $name, browser_download_url: ("https://example.invalid/" + $name)},
+      {name: ($name + ".sha256"), browser_download_url: ("https://example.invalid/" + $name + ".sha256")}
+    ]
+  }' >"$FAKE_RELEASE_JSON"
+}
+
+run_updater() {
+  PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$sandbox/cache" \
+    "$plugin/bin/nearby-update-helper" 2>/dev/null
+}
+
+installed_helper() { cat "$plugin/bin/omarchy-nearby-helper"; }
+staging_in_plugin() { find "$plugin/bin" -maxdepth 1 -name '.update.*' | wc -l; }
+staging_in_cache() { find "$sandbox/cache" -mindepth 1 -maxdepth 2 -name 'update.*' 2>/dev/null | wc -l; }
+
+# --- a release that exists, with a checksum that matches -----------------
+
+announce "success replaces the binary, reports done, and exits 0"
+setup
+output=$(run_updater); status=$?
+assert_eq "$status" "0" "a verified install must not report failure"
+assert_contains "$output" '{"event":"done","version":"1.1.0"}'
+assert_eq "$(installed_helper)" "new helper 1.1.0"
+assert_eq "$(staging_in_cache)" "0" "the staging directory must be cleaned up"
+assert_eq "$(staging_in_plugin)" "0" "nothing may be left inside the watched plugin directory"
+teardown
+
+announce "progress is reported as one JSON object per line"
+setup
+output=$(run_updater)
+assert_contains "$output" '"event":"step"'
+assert_contains "$output" 'Looking up Nearby v1.1.0'
+assert_contains "$output" 'Verifying checksum'
+while IFS= read -r line; do
+  [[ -n $line ]] || continue
+  jq -e . >/dev/null 2>&1 <<<"$line" || report "not JSON: $line"
+done <<<"$output"
+teardown
+
+# The sweep loop runs last and used to decide the exit status: with no orphan
+# to match, the glob stayed literal, the test failed, and a successful update
+# reported failure to the panel.
+announce "an orphan staging directory is swept without changing the exit status"
+setup
+mkdir -p "$plugin/bin/.update.leftover"
+printf 'junk\n' >"$plugin/bin/.update.leftover/partial"
+output=$(run_updater); status=$?
+assert_eq "$status" "0"
+assert_eq "$(staging_in_plugin)" "0" "a leftover staging directory must be swept"
+assert_contains "$output" '"event":"done"'
+teardown
+
+# --- the plugin directory is off limits until the binary is ready --------
+
+# Writing into the plugin tree makes the shell reload the plugin, which tears
+# down the service and kills this process. Staging there meant the download was
+# killed partway through, every time, and left its directory behind.
+announce "nothing is written into the plugin directory before the final rename"
+setup
+before=$(find "$plugin" | sort)
+FAKE_ASSET_DELAY=3 PATH="$stub_bin:$PATH" XDG_CACHE_HOME="$sandbox/cache" \
+  "$plugin/bin/nearby-update-helper" >/dev/null 2>&1 &
+updater_pid=$!
+sleep 1.5
+kill -KILL "$updater_pid" 2>/dev/null
+wait "$updater_pid" 2>/dev/null
+after=$(find "$plugin" | sort)
+assert_eq "$after" "$before" "a download in flight must leave the plugin directory untouched"
+assert_eq "$(installed_helper)" "old helper" "a killed update must not have replaced the binary"
+teardown
+
+# --- failures leave the old helper in place ------------------------------
+
+announce "a checksum mismatch discards the download"
+setup
+printf 'tampered\n' >"$sandbox/served/$asset_name"
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "failed its SHA256 check"
+assert_eq "$(installed_helper)" "old helper" "an unverified binary must never be installed"
+assert_eq "$(staging_in_cache)" "0"
+assert_eq "$(staging_in_plugin)" "0"
+teardown
+
+# "no such release" and "no network" are different problems with different
+# fixes. curl --fail reports both as a non-zero exit, and collapsing them told
+# users to check a connection that was working.
+announce "a missing release is not reported as a connection problem"
+setup
+export FAKE_HTTP_STATUS=404
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "GitHub has no release v1.1.0"
+assert_not_contains "$output" "Check your connection"
+teardown
+
+announce "an unreachable host is reported as a connection problem"
+setup
+export FAKE_LOOKUP_EXIT=6
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "Could not reach GitHub"
+assert_contains "$output" "Check your connection"
+assert_not_contains "$output" "has no release"
+teardown
+
+announce "a rate limit says to wait rather than to retry now"
+setup
+export FAKE_HTTP_STATUS=403
+output=$(run_updater)
+assert_contains "$output" "rate-limiting"
+teardown
+
+announce "a server error is distinguished from a missing release"
+setup
+export FAKE_HTTP_STATUS=503
+output=$(run_updater)
+assert_contains "$output" "HTTP 503"
+assert_not_contains "$output" "has no release"
+teardown
+
+announce "a development checkout is told to build, not to retry the network"
+setup
+manifest "1.1.1-dev"
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "development build"
+assert_contains "$output" "./build.sh"
+assert_not_contains "$output" '"event":"step"' "a version with no release must fail before reaching the network"
+teardown
+
+announce "a release without a helper for this architecture says so"
+setup
+release_json "omarchy-nearby-helper-v1.1.0-linux-somethingelse" false false
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "publishes no"
+assert_eq "$(installed_helper)" "old helper"
+teardown
+
+announce "a draft release is refused"
+setup
+release_json "$asset_name" true false
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "draft"
+teardown
+
+announce "a prerelease is refused"
+setup
+release_json "$asset_name" false true
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "prerelease"
+teardown
+
+announce "a broken manifest fails before the network"
+setup
+printf 'not json\n' >"$plugin/manifest.json"
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "not valid JSON"
+teardown
+
+announce "every failure is a single JSON object the panel can parse"
+setup
+export FAKE_HTTP_STATUS=404
+output=$(run_updater)
+last=$(tail -1 <<<"$output")
+assert_eq "$(jq -r '.event' <<<"$last")" "failed"
+[[ -n $(jq -r '.message' <<<"$last") ]] || report "a failure must carry a message"
+teardown
+
+if (( failures )); then
+  echo "updater tests failed: $failures" >&2
+  exit 1
+fi
+echo "updater tests passed"


### PR DESCRIPTION
Refs #7. Last of a stacked series of four.

**Builds on #8, #9 and #10.** The new commit here is `feat: update the helper from the panel when the plugin outgrows it`; the three below it are those PRs and shrink out of this diff as they merge.

## Problem

With #10 in place a mismatch is rare, but when it happens the receiver stops and the only way out is a terminal. Omarchy cannot close that gap: `omarchy plugin update` runs nothing the plugin ships and there is no manifest hook to add. The plugin can close it.

## Change

The panel offers an **Update helper** button. It runs `bin/nearby-update-helper`, which resolves the GitHub release matching `manifest.json`, verifies the download against the release SHA256, replaces `bin/omarchy-nearby-helper` and lets the service restart the receiver. Also reachable headless:

```sh
omarchy-shell oma.nearby updateHelper
```

`status` now reports the helper version, the floor it must clear and whether an update is on offer, so a mismatch is no longer indistinguishable from a port conflict.

**Deliberately not `install.sh`.** That script also owns the git checkout and refuses to run against a plugin directory with local changes, so it cannot be what a button calls. `omarchy plugin update` already moves the source; the only thing it cannot move is the binary. Splitting the two leaves the git side to Omarchy, and `install.sh` stays the way to move plugin and helper to a release together.

## Two properties this depends on, both learned the hard way

- **The shell watches the plugin directory** and reloads the plugin on any change, tearing down the service and killing its child processes. Staging the download under `bin/` got the updater SIGKILLed partway through, every time, leaving orphan directories. It stages in the XDG cache instead — same filesystem, so the final `mv` is still atomic and the only change the watcher sees is a rename of an already-verified binary.
- **That same reload can kill the updater one line after its work is done**, losing its exit status. The `done` message is therefore authoritative over the exit code, so a completed update is never reported as a failure.

## Failure behaviour

A missing release, a rate limit and an unreachable host are reported separately rather than collapsed into "check your connection" — `curl --fail` returns non-zero for all three, which is what made the original message wrong. When the fetch cannot succeed the panel falls back to the installer command and the repository, both copyable.

## `.gitignore`

`bin/*` is ignored, so the updater would silently not ship. Added `!bin/nearby-update-helper` — it is source, not a build product.

## Tests

New `tests/updater.test.sh` covers the script offline with a `curl` stub on PATH, so it needs no seam of its own and no network: verified install and atomic replace, JSON-per-line output, orphan sweep, checksum mismatch discarding the download, 404 vs unreachable host vs rate limit vs 5xx, a development checkout failing before any network call, missing architecture asset, draft and prerelease refusal, broken manifest, and a **kill mid-download asserting the plugin directory is byte-identical** — the reload bug above, encoded.

Added to CI as its own step.

I mutation-tested that suite rather than trusting a green run. Collapsing 404 back into the connection message, staging inside the plugin directory, skipping the checksum, and the original sweep loop that made successful runs exit 1 are all caught. One survivor was an equivalent mutant.

`tests/service-state.test.js` and `tests/panel-state.test.js` cover the update lifecycle, the killed-after-install case, the binding restore, and the row order and keyboard index of the new button.

## Verification

Full suite plus all four cargo checks pass.

Smoke-tested on Omarchy with Quattro, end to end: installed the genuine v1.0.7 release helper under a 1.1.0 plugin, confirmed the mismatch state and the stopped receiver, pressed the button, watched it fetch and verify v1.1.0 and bring the receiver back up ready. Failure rendering checked by pointing the manifest at a nonexistent release. Real-device LocalSend transfers are untouched and were not re-tested.