### PR TITLE
fix: keep helper recovery actionable in development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,14 @@ interoperability, a real LocalSend peer.
   maintenance or correctness benefit.
 - Preserve contributor authorship and keep release preparation separate from a
   contributor's functional commits.
+- Merge stacked pull requests in dependency order. After each merge, update the
+  next branch against the current `main`, prefer rebasing when it is safe, and
+  re-review the effective diff before merging it.
+- Do not merge `main` into a contributor branch merely to refresh a stacked
+  pull request's merge base. Avoid synchronization commits unless a concrete
+  technical reason makes one necessary, and preserve contributor authorship
+  when updating or rebasing the branch.
+- Do not rewrite published `main` solely to make its history look cleaner.
 - Stable releases require matching versions in `manifest.json`,
   `backend/Cargo.toml`, and `backend/Cargo.lock`, plus a matching changelog
   heading and `vX.Y.Z` tag.

--- a/Model.js
+++ b/Model.js
@@ -226,6 +226,11 @@ function helperSatisfies(requiredVersion, helperVersion) {
 
 // Usable but behind: worth offering an update, not worth stopping for.
 function helperUpdateAvailable(pluginVersion, helperVersion) {
+  // Release assets exist only for stable versions. A compatible helper may be
+  // older than a development checkout, but offering an update in that state
+  // can only lead to the updater's "no published helper" failure.
+  const plugin = parseVersion(pluginVersion)
+  if (!plugin || plugin.prerelease.length !== 0) return false
   const order = compareVersions(helperVersion, pluginVersion)
   return order !== null && order < 0
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -63,11 +63,15 @@ Panel {
   readonly property string repositoryUrl: "https://github.com/jfg96/omarchy-nearby"
   readonly property string installerCommand: "~/.config/omarchy/plugins/oma.nearby/install.sh"
 
-  // The update row is the last thing in the Nearby view, so it sits after the
-  // devices and after the compact action row when that row is there at all.
+  // The update row sits after the devices and compact action row. If updating
+  // fails, its two recovery actions follow it in keyboard order.
   readonly property int helperUpdateIndex: !helperUpdateOffered
     ? -1
     : (receiverEnabled && backendReady ? devices.length + 2 : devices.length)
+  readonly property int helperCopyCommandIndex: helperUpdateError === "" || helperUpdateIndex < 0
+    ? -1 : helperUpdateIndex + 1
+  readonly property int helperCopyLinkIndex: helperCopyCommandIndex < 0
+    ? -1 : helperCopyCommandIndex + 1
 
   // Cursor and popup focus are per monitor, so they stay here.
   property int selectedIndex: 0
@@ -181,12 +185,17 @@ Panel {
   function moveCursor(dx, dy) {
     cursorActive = true
     if (viewState === "nearby") {
-      // The update row, when it is showing, is the last stop in either
-      // direction: without it a panel reporting an unusable helper has nothing
-      // below the receiver switch to reach.
-      var lastNearbyIndex=helperUpdateIndex>=0
-        ? helperUpdateIndex
-        : (receiverEnabled&&backendReady ? devices.length+1 : Math.max(-1,devices.length-1))
+      // The update row is the last stop until a failure reveals the two
+      // recovery actions that follow it.
+      var lastNearbyIndex=helperCopyLinkIndex>=0
+        ? helperCopyLinkIndex
+        : (helperUpdateIndex>=0
+          ? helperUpdateIndex
+          : (receiverEnabled&&backendReady ? devices.length+1 : Math.max(-1,devices.length-1)))
+      if (dx !== 0 && helperCopyCommandIndex >= 0 && selectedIndex >= helperCopyCommandIndex) {
+        selectedIndex = Math.max(helperCopyCommandIndex, Math.min(helperCopyLinkIndex, selectedIndex + dx))
+        return
+      }
       if (dx !== 0 && selectedIndex >= devices.length) {
         selectedIndex = Math.max(devices.length, Math.min(lastNearbyIndex, selectedIndex + dx))
         return
@@ -211,6 +220,8 @@ Panel {
       // hidden, and the update button takes the index rescan would have had.
       if (selectedIndex < 0) toggleReceiver()
       else if (helperUpdateIndex >= 0 && selectedIndex === helperUpdateIndex) updateHelper()
+      else if (helperCopyCommandIndex >= 0 && selectedIndex === helperCopyCommandIndex) copyInstallerCommand()
+      else if (helperCopyLinkIndex >= 0 && selectedIndex === helperCopyLinkIndex) copyRepositoryLink()
       else if (selectedIndex < devices.length) chooseDevice(selectedIndex)
       else if (receiverEnabled && backendReady && selectedIndex === devices.length) forceFullDiscovery()
       else if (receiverEnabled && backendReady && selectedIndex === devices.length+1) openIncomingPinSettings()
@@ -412,8 +423,8 @@ Panel {
               Text { width:parent.width; textFormat:Text.PlainText; text:root.installerCommand; elide:Text.ElideMiddle; color:root.foreground; font.family:root.fontFamily; font.pixelSize:Style.font.body }
               Row {
                 width:parent.width; spacing:Style.space(8)
-                Button { width:(parent.width-parent.spacing)/2; bordered:true; iconText:"󰆏"; text:"Copy command"; tooltipText:root.installerCommand; foreground:root.foreground; fontFamily:root.fontFamily; onClicked:root.copyInstallerCommand() }
-                Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰌷"; text:"Copy link"; tooltipText:root.repositoryUrl; foreground:root.dim; fontFamily:root.fontFamily; onClicked:root.copyRepositoryLink() }
+                Button { width:(parent.width-parent.spacing)/2; bordered:true; iconText:"󰆏"; text:"Copy command"; tooltipText:root.installerCommand; foreground:root.foreground; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.helperCopyCommandIndex; onHovered:function(v){root.noteHover(v,root.helperCopyCommandIndex)}; onClicked:root.copyInstallerCommand() }
+                Button { width:(parent.width-parent.spacing)/2; bordered:false; iconText:"󰌷"; text:"Copy link"; tooltipText:root.repositoryUrl; foreground:root.dim; fontFamily:root.fontFamily; hasCursor:root.cursorActive&&root.selectedIndex===root.helperCopyLinkIndex; onHovered:function(v){root.noteHover(v,root.helperCopyLinkIndex)}; onClicked:root.copyRepositoryLink() }
               }
               Text { visible:root.copyNote!==""; width:parent.width; textFormat:Text.PlainText; text:root.copyNote; color:root.dim; font.family:root.fontFamily; font.pixelSize:Style.font.body }
             }

--- a/Service.qml
+++ b/Service.qml
@@ -97,7 +97,8 @@ Item {
   property string helperUpdateStatus: ""
   property string helperUpdateError: ""
   // Behind but still usable: the version floor accepts it, so this is a nudge
-  // rather than a stop.
+  // rather than a stop. Development versions have no release asset, so they
+  // never offer an optional update that is guaranteed to fail.
   readonly property bool helperOutdated: helperVersion !== "" && pluginVersion !== ""
     && Model.helperUpdateAvailable(pluginVersion, helperVersion)
   readonly property bool helperUpdateOffered: pluginVersion !== ""

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -69,6 +69,10 @@ assert.equal(Model.helperUpdateAvailable("1.1.0", "1.0.7"), true)
 assert.equal(Model.helperUpdateAvailable("1.1.0", "1.1.0"), false)
 assert.equal(Model.helperUpdateAvailable("1.1.0", "1.2.0"), false)
 assert.equal(Model.helperUpdateAvailable("1.1.0", ""), false)
+assert.equal(Model.helperUpdateAvailable("1.1.1-dev", "1.1.0"), false,
+  "a development checkout has no matching release asset to offer")
+assert.equal(Model.helperUpdateAvailable("1.1.1-rc.1", "1.1.0"), false,
+  "prereleases must not offer an optional stable-helper download")
 
 assert.equal(Model.manifestMinHelperVersion('{"id":"oma.nearby","version":"1.1.0","minHelperVersion":"1.0.6"}', "oma.nearby"), "1.0.6")
 assert.equal(Model.manifestMinHelperVersion('{"id":"oma.nearby","version":"1.1.0"}', "oma.nearby"), "",

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -75,6 +75,10 @@ assert.match(source, /enabled:!root\.helperUpdating/,
   "a second press while the updater runs must not start a second download")
 assert.match(source, /visible:root\.helperUpdateError!==""[\s\S]*?root\.installerCommand[\s\S]*?onClicked:root\.copyInstallerCommand\(\)[\s\S]*?onClicked:root\.copyRepositoryLink\(\)/,
   "a failed update must offer the command that fixes it, not only the repository link")
+assert.match(source, /text:"Copy command"[^\n]*hasCursor:[^\n]*helperCopyCommandIndex[^\n]*onHovered:[^\n]*helperCopyCommandIndex/,
+  "the copy-command fallback must participate in keyboard and hover navigation")
+assert.match(source, /text:"Copy link"[^\n]*hasCursor:[^\n]*helperCopyLinkIndex[^\n]*onHovered:[^\n]*helperCopyLinkIndex/,
+  "the copy-link fallback must participate in keyboard and hover navigation")
 assert.match(source, /readonly property string repositoryUrl: "https:\/\/github\.com\/jfg96\/omarchy-nearby"/,
   "the fallback link must point at the repository the installer pulls from")
 assert.equal(source.includes("install.sh\"]"), false,
@@ -199,9 +203,10 @@ function stubEngine() {
 // pulled out of the source and evaluated rather than restated here: a copy of
 // the expression could not catch it drifting away from the order the panel
 // actually draws, which is the whole point of asserting on it.
-function helperUpdateIndexExpression() {
-  const match = source.match(/readonly property int helperUpdateIndex:\s*([\s\S]*?)\n\s*\n/)
-  assert.notEqual(match, null, "Panel.qml must bind helperUpdateIndex")
+function intBindingExpression(name) {
+  const match = source.match(new RegExp(
+    `readonly property int ${name}:\\s*([\\s\\S]*?)(?=\\n\\s*(?:readonly property|property |//))`))
+  assert.notEqual(match, null, `Panel.qml must bind ${name}`)
   return match[1].trim()
 }
 
@@ -218,6 +223,9 @@ function panel(initial = {}) {
     textCopier: {running: false, launched: false, payload: ""},
     copyNote: "",
     helperUpdateOffered: false,
+    helperUpdateError: "",
+    installerCommand: "~/.config/omarchy/plugins/oma.nearby/install.sh",
+    repositoryUrl: "https://github.com/jfg96/omarchy-nearby",
     pinInput: {text: "", forceActiveFocus: () => {}},
     incomingPinInput: {text: "", forceActiveFocus: () => {}},
     keyCatcher: {forceActiveFocus: () => {}},
@@ -237,20 +245,40 @@ function panel(initial = {}) {
     ...initial,
   }
   context.engine = engine
-  const indexExpression = helperUpdateIndexExpression()
-  Object.defineProperty(context, "helperUpdateIndex", {
-    enumerable: true,
-    get: () => vm.runInNewContext(`(${indexExpression})`, {
-      helperUpdateOffered: context.helperUpdateOffered,
-      receiverEnabled: context.receiverEnabled,
-      backendReady: context.backendReady,
-      devices: context.devices,
-    }),
-  })
+  for (const name of ["helperUpdateIndex", "helperCopyCommandIndex", "helperCopyLinkIndex"]) {
+    const expression = intBindingExpression(name)
+    Object.defineProperty(context, name, {
+      enumerable: true,
+      get: () => vm.runInNewContext(`(${expression})`, context),
+    })
+  }
   vm.createContext(context)
   vm.runInContext(functionNames.map(extractFunction).join("\n"), context)
   context.closes = closes
   return context
+}
+
+// A failed update adds two recovery controls after the retry button. Both have
+// to be reachable and activatable without a pointer.
+{
+  const state = panel({
+    viewState: "nearby", devices: [], backendReady: false, helperUpdateOffered: true,
+    helperUpdateError: "offline", selectedIndex: 0,
+  })
+  assert.equal(state.helperUpdateIndex, 0)
+  assert.equal(state.helperCopyCommandIndex, 1)
+  assert.equal(state.helperCopyLinkIndex, 2)
+
+  state.moveCursor(0, 1)
+  assert.equal(state.selectedIndex, 1)
+  state.activateCursor()
+  assert.equal(state.textCopier.payload, state.installerCommand)
+
+  state.textCopier.running = false
+  state.moveCursor(1, 0)
+  assert.equal(state.selectedIndex, 2)
+  state.activateCursor()
+  assert.equal(state.textCopier.payload, state.repositoryUrl)
 }
 
 function callNames(state) {

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -343,6 +343,21 @@ for (const [name, setup] of [
   assert.equal(state.helperUpdateOffered, true, "a helper above the floor but behind the plugin is still worth updating")
   assert.match(state.helperUpdateDetail, /behind plugin 1\.1\.0/)
 }
+{
+  const state = engine({pluginVersion: "1.1.1-dev", minHelperVersion: "1.1.0", helperVersion: "1.1.0"})
+  assert.equal(state.helperOutdated, false)
+  assert.equal(state.helperUpdateOffered, false,
+    "a compatible helper must not offer an impossible optional update for a development checkout")
+}
+{
+  const state = engine({
+    pluginVersion: "1.1.1-dev", minHelperVersion: "1.1.1-dev", helperVersion: "1.1.0",
+    backendVersionMismatch: true,
+  })
+  assert.equal(state.helperUpdateOffered, true,
+    "an incompatible helper must still expose the recovery UI on a development checkout")
+  assert.match(state.helperUpdateDetail, /Needs helper 1\.1\.1-dev/)
+}
 
 // No floor declared reads as the shipped version, which is the rule the plugin
 // followed before the field existed.


### PR DESCRIPTION
## Summary

- do not offer an optional helper update for development/prerelease plugin versions that have no downloadable release asset
- continue offering recovery when the installed helper is actually below `minHelperVersion`
- integrate `Copy command` and `Copy link` into the panel keyboard cursor and activation model
- document the preferred stacked-PR workflow in a separate policy-only commit

## Validation

- `node tests/model.test.js`
- `node tests/panel-state.test.js`
- `node tests/service-state.test.js`
- `bash tests/updater.test.sh`
- `cargo fmt --manifest-path backend/Cargo.toml --all -- --check`
- `cargo check --locked --manifest-path backend/Cargo.toml`
- `cargo test --locked --manifest-path backend/Cargo.toml`
- `cargo test --locked --manifest-path backend/vendor/localsend-rs/Cargo.toml --features https`

No release, tag, stable version, or binary is created by this PR.