### PR TITLE
fix: stop notifying about what the open panel already shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.1.2-dev
 
+- Stop duplicating an incoming transfer or received text as a desktop
+  notification when the Nearby panel is already open on it. Arrivals the open
+  panel holds back instead of displaying — behind a transfer in progress, a PIN
+  prompt, or an earlier queued request — are still announced.
+
 ## 1.1.1
 
 - Keep the hero status short and readable while showing the complete error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.1.2-dev
+
 ## 1.1.1
 
 - Keep the hero status short and readable while showing the complete error

--- a/Service.qml
+++ b/Service.qml
@@ -189,6 +189,18 @@ Item {
     if (openViewCount === 0) stopDiscovery()
   }
 
+  // A desktop notification exists to reach a user who is not looking at the
+  // panel. Raising one for something the open panel is already showing is a
+  // duplicate the user has to dismiss on top of the prompt they are answering.
+  //
+  // Open is not enough on its own: an arrival during a transfer, a PIN prompt,
+  // or behind an earlier queued request is held back rather than displayed, so
+  // the panel being open would otherwise swallow it silently. The caller says
+  // whether this particular event reached the screen.
+  function notificationNeeded(onScreen) {
+    return !anyViewOpen || !onScreen
+  }
+
   function send(command) {
     if (!backend.running) return
     backend.write(JSON.stringify(command) + "\n")
@@ -460,13 +472,17 @@ Item {
     else if (event.event === "discovery_stopped") discoveryActive=false
     else if (event.event === "incoming_request") {
       if(viewState.indexOf("incoming_pin_")===0){incomingPinError="";incomingPinCleared()}
-      incomingQueue=Model.enqueueIncoming(incomingQueue,event); if(!incomingTextPending)incomingText=""; if (viewState!=="sending" && viewState!=="receiving" && viewState!=="pin") { viewState="incoming"; cursorRequested(1) }
-      Quickshell.execDetached(["notify-send","-a","Nearby","Incoming transfer",String(event.sender)+" wants to send "+Model.incomingSummary(event.files)])
+      incomingQueue=Model.enqueueIncoming(incomingQueue,event); if(!incomingTextPending)incomingText=""
+      var incomingTakesView = viewState!=="sending" && viewState!=="receiving" && viewState!=="pin"
+      if (incomingTakesView) { viewState="incoming"; cursorRequested(1) }
+      if (notificationNeeded(incomingTakesView && incoming && incoming.requestId===event.requestId))
+        Quickshell.execDetached(["notify-send","-a","Nearby","Incoming transfer",String(event.sender)+" wants to send "+Model.incomingSummary(event.files)])
     }
     else if (event.event === "incoming_text") {
       if(viewState.indexOf("incoming_pin_")===0){incomingPinError="";incomingPinCleared()}
       incomingText=String(event.text || ""); transferPeer=String(event.sender || ""); incomingTextPending=pendingOutgoing!==null; if (!pendingOutgoing) { viewState="text"; stopDiscovery() }
-      Quickshell.execDetached(["notify-send","-a","Nearby","Text received","From "+String(event.sender || "")])
+      if (notificationNeeded(!incomingTextPending))
+        Quickshell.execDetached(["notify-send","-a","Nearby","Text received","From "+String(event.sender || "")])
     }
     else if (event.event === "incoming_accepted") { incomingQueue=Model.removeIncoming(incomingQueue,event.requestId) }
     else if (event.event === "incoming_expired") {

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "omarchy-nearby-helper"
-version = "1.1.1"
+version = "1.1.2-dev"
 dependencies = [
  "anyhow",
  "localsend-rs",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omarchy-nearby-helper"
-version = "1.1.1"
+version = "1.1.2-dev"
 edition = "2024"
 license = "MIT"
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "oma.nearby",
   "name": "Nearby",
-  "version": "1.1.1",
+  "version": "1.1.2-dev",
   "minHelperVersion": "1.1.0",
   "author": "jfg96",
   "description": "Native nearby sharing compatible with the LocalSend protocol",

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -134,7 +134,7 @@ function helperDerived(state) {
 }
 
 const functionNames = [
-  "viewOpened", "viewClosed",
+  "viewOpened", "viewClosed", "notificationNeeded",
   "send", "bindBackendRunning", "persistReceiverEnabled", "toggleReceiver", "finishReceiverShutdown",
   "startDiscovery", "forceFullDiscovery", "stopDiscovery", "chooseDevice", "clearTarget",
   "openIncomingPinSettings", "beginIncomingPinEdit", "requestDisableIncomingPin",
@@ -150,11 +150,12 @@ const functionNames = [
 function engine(initial = {}) {
   const sent = []
   const cursors = []
+  const notified = []
   const signals = {pinCleared: 0, pinFocusRequested: 0, incomingPinCleared: 0, incomingPinFocusRequested: 0, focusRestoreRequested: 0}
   const context = {
     Model,
     Date: {now: () => 1000},
-    Quickshell: {execDetached: () => {}},
+    Quickshell: {execDetached: command => notified.push(command)},
     Qt: {binding: callback => ({callback})},
     backend: {running: true, write: line => sent.push(JSON.parse(line))},
     backendRestart: {attempts: 0, interval: 0, restart: () => {}, stop: () => {}},
@@ -227,8 +228,15 @@ function engine(initial = {}) {
   vm.runInContext(functionNames.map(extractFunction).join("\n"), context)
   context.sent = sent
   context.cursors = cursors
+  context.notified = notified
   context.signals = signals
   return context
+}
+
+function notificationTitles(state) {
+  return state.notified
+    .filter(command => command[0] === "notify-send")
+    .map(command => command[3])
 }
 
 {
@@ -548,6 +556,74 @@ function incoming(requestId, sender = requestId) {
   assert.equal(state.viewState, "text")
   assert.ok(state.signals.incomingPinCleared > before,
     "incoming text that preempts PIN settings must clear the local secret field")
+}
+
+// A desktop notification exists to reach a user who is not looking at the
+// panel. Raised while the panel is open on the very request it announces, it is
+// a duplicate the user has to dismiss on top of answering the prompt.
+{
+  const state = engine({viewState: "nearby", openViewCount: 1, anyViewOpen: true})
+  state.handleEvent(incoming("visible"))
+  assert.equal(state.viewState, "incoming")
+  assert.deepEqual(notificationTitles(state), [],
+    "a panel already showing the request must not also raise a notification")
+}
+
+{
+  const state = engine({viewState: "nearby", openViewCount: 0, anyViewOpen: false})
+  state.handleEvent(incoming("unseen"))
+  assert.deepEqual(notificationTitles(state), ["Incoming transfer"],
+    "a closed panel is the case the notification exists for")
+}
+
+// Open is not the same as displayed. A request that arrives while the panel is
+// busy is queued rather than shown, so going quiet would drop it silently.
+for (const busy of ["sending", "receiving", "pin"]) {
+  const state = engine({viewState: busy, anyViewOpen: true})
+  state.handleEvent(incoming("held"))
+  assert.equal(state.viewState, busy)
+  assert.deepEqual(notificationTitles(state), ["Incoming transfer"],
+    `a request held behind ${busy} is not on screen and still has to be announced`)
+}
+
+// The panel shows the head of the queue, so a second request is not visible
+// either even though the view is already the incoming one.
+{
+  const state = engine({viewState: "nearby", anyViewOpen: true})
+  state.handleEvent(incoming("first"))
+  state.handleEvent(incoming("second"))
+  assert.equal(state.incoming.requestId, "first")
+  assert.deepEqual(notificationTitles(state), ["Incoming transfer"],
+    "only the request queued behind the displayed one may notify")
+}
+
+// Received text follows the same rule.
+{
+  const state = engine({viewState: "nearby", anyViewOpen: true})
+  state.handleEvent({event: "incoming_text", sender: "Alice", text: "hello"})
+  assert.equal(state.viewState, "text")
+  assert.deepEqual(notificationTitles(state), [],
+    "a panel already showing the text must not also raise a notification")
+}
+
+{
+  const state = engine({viewState: "nearby", anyViewOpen: false})
+  state.handleEvent({event: "incoming_text", sender: "Alice", text: "hello"})
+  assert.deepEqual(notificationTitles(state), ["Text received"])
+}
+
+// Its held case is an outgoing transfer in flight: the text is kept until the
+// send finishes instead of being shown, so the open panel does not cover it.
+{
+  const state = engine({
+    viewState: "sending",
+    anyViewOpen: true,
+    pendingOutgoing: {kind: "text", device: {fingerprint: "phone"}, text: "outgoing"},
+  })
+  state.handleEvent({event: "incoming_text", sender: "Alice", text: "deferred"})
+  assert.equal(state.incomingTextPending, true)
+  assert.deepEqual(notificationTitles(state), ["Text received"],
+    "text deferred behind an outgoing transfer is not on screen and still has to be announced")
 }
 
 {


### PR DESCRIPTION
## Problem

`incoming_request` and `incoming_text` each raised a `notify-send` desktop
notification unconditionally. When the Nearby panel was already open, the panel
switched to the arrival *and* a notification appeared announcing the same thing.
The user ended up with two copies of one prompt and had to dismiss the
notification on top of answering the panel.

## Fix

Suppress the notification when a view is open **and** that view is showing this
particular arrival.

Openness alone is not the right test. The panel deliberately holds some
arrivals back rather than displaying them, and going quiet on those would lose
them silently:

- an `incoming_request` arriving during `sending`, `receiving`, or a PIN prompt
  is queued and the view does not change;
- a second `incoming_request` sits behind the queue head, which is what the
  panel renders;
- an `incoming_text` arriving while an outgoing transfer is in flight is kept in
  `incomingTextPending` and only shown once the send finishes.

Each of those is invisible with the panel open, so the notification is the only
thing that reports it. `notificationNeeded(onScreen)` therefore takes the
per-event answer instead of reading `anyViewOpen` on its own.

## Tests

`tests/service-state.test.js` covers both directions:

- panel open and displaying the request / the text -> no notification;
- panel closed -> notification;
- request held behind `sending`, `receiving`, `pin` -> notification with the
  panel open;
- request queued behind the displayed one -> notification;
- text deferred behind an outgoing transfer -> notification.

The suppression assertions fail against the pre-fix source for the expected
reason, and the held-case assertions fail against a naive `!anyViewOpen` guard.

## Version

`main` is at stable `v1.1.1`, so this opens the `1.1.2-dev` cycle in a separate
`chore:` commit (`manifest.json`, `backend/Cargo.toml`, `backend/Cargo.lock`,
changelog heading), keeping release preparation out of the functional commit.
`minHelperVersion` is unchanged: nothing in the helper protocol moved.

## Validation

```
node tests/model.test.js
node tests/panel-state.test.js
node tests/service-state.test.js
bash tests/updater.test.sh
cargo fmt --manifest-path backend/Cargo.toml --all -- --check
cargo check --locked --manifest-path backend/Cargo.toml
cargo test --locked --manifest-path backend/Cargo.toml
cargo test --locked --manifest-path backend/vendor/localsend-rs/Cargo.toml --features https
```

All pass. Not smoke-tested on Omarchy against a real LocalSend peer.