### PR TITLE
feat: dim bar icon when receiver is disabled

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -28,6 +28,7 @@ Panel {
   readonly property color urgent: bar ? bar.urgent : Color.urgent
   readonly property color dim: Qt.darker(foreground, 1.4)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
+  readonly property color barIconColor: root.receiverEnabled ? barForeground : Qt.darker(barForeground, 1.55)
 
   // Engine state, read under the names the popup already used. A view with no
   // engine says so rather than rendering an empty panel.
@@ -311,6 +312,7 @@ Panel {
 
   BarIconButton {
     id: button; anchors.fill: parent; bar: root.bar; text: "󰀂"
+    foreground: root.barIconColor
     active: root.incoming !== null || root.viewState === "receiving" || root.viewState === "sending" || root.viewState === "pin"
     tooltipText: !root.receiverEnabled ? "Nearby · Turned off" : (root.backendReady ? (root.viewState === "pin" ? "Nearby · PIN required" : (root.incoming ? "Incoming transfer" : "Nearby · Ready to receive")) : "Nearby · Receiver unavailable")
     onPressed: function(code) { root.toggle() }

--- a/tests/panel-state.test.js
+++ b/tests/panel-state.test.js
@@ -18,6 +18,10 @@ assert.match(source, /bar\.shell\.serviceFor\(manifestPluginId\)/,
   "the widget must read its state from the single service instance")
 assert.match(source, /manageIpc:\s*false/,
   "the base panel's IPC handler must stay off so the service owns the target")
+assert.match(source, /barIconColor:\s*root\.receiverEnabled\s*\?\s*barForeground\s*:\s*Qt\.darker\(barForeground,\s*1\.55\)/,
+  "the bar icon must dim when receiver is disabled")
+assert.match(source, /BarIconButton[\s\S]*?foreground:\s*root\.barIconColor/,
+  "the bar icon button must use barIconColor")
 assert.equal(source.includes("Qt.ImhDigitsOnly"), false,
   "the outgoing PIN prompt must accept the same text values as LocalSend")
 assert.equal(source.includes("RegularExpressionValidator { regularExpression: /[0-9]*/ }"), false,


### PR DESCRIPTION
Matches the inactive bar icon appearance of first-party Omarchy status widgets (e.g. Tailscale, sing-box) by darkening the glyph with `Qt.darker(barForeground, 1.55)` when `receiverEnabled` is false. Includes unit test assertion in `tests/panel-state.test.js`.