### PR TITLE
chore: prepare v1.1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.1.4
+
+- Dim the Nearby bar icon while the receiver is disabled, while preserving the
+  existing toggle behavior.
+- Fall back to the system hostname when the `HOSTNAME` environment variable is
+  unavailable, so the helper can still start with a stable device alias.
+- Send incoming transfer and text notifications through Omarchy's native
+  `omarchy-notification-send` helper. Nearby keeps its own application identity
+  so notifications respect Do Not Disturb, and explicitly retains normal
+  urgency to preserve the previous popup duration and priority.
+
 ## 1.1.3
 
 - Restore the receiver ON/OFF toggle on recent Omarchy releases after the

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "omarchy-nearby-helper"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "anyhow",
  "localsend-rs",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omarchy-nearby-helper"
-version = "1.1.3"
+version = "1.1.4"
 edition = "2024"
 license = "MIT"
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "oma.nearby",
   "name": "Nearby",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "minHelperVersion": "1.1.0",
   "author": "jfg96",
   "description": "Native nearby sharing compatible with the LocalSend protocol",


### PR DESCRIPTION
## Summary

- document the receiver icon, hostname fallback, and native notification changes
- align manifest and helper versions at 1.1.4
- keep release publication delegated to the tag workflow

## Validation

- node tests/model.test.js
- node tests/panel-state.test.js
- node tests/service-state.test.js
- bash tests/updater.test.sh
- cargo fmt --manifest-path backend/Cargo.toml --all -- --check
- cargo check --locked --manifest-path backend/Cargo.toml
- cargo test --locked --manifest-path backend/Cargo.toml
- cargo test --locked --manifest-path backend/vendor/localsend-rs/Cargo.toml --features https
- git diff --check