### PR TITLE
Harden Nearby runtime and release chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,16 @@ concurrency:
 jobs:
   test:
     name: CI checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out source
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
         with:
-          components: rustfmt
+          toolchain: 1.97.1
+          components: rustfmt, clippy
 
       - name: Test frontend model
         run: node tests/model.test.js && node tests/panel-state.test.js && node tests/service-state.test.js
@@ -39,6 +40,9 @@ jobs:
 
       - name: Check Nearby helper builds
         run: cargo check --locked --manifest-path backend/Cargo.toml
+
+      - name: Lint Nearby helper
+        run: cargo clippy --all-targets --locked --manifest-path backend/Cargo.toml -- -D warnings
 
       - name: Test Nearby helper
         run: cargo test --locked --manifest-path backend/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
       - name: Test frontend model
         run: node tests/model.test.js && node tests/panel-state.test.js && node tests/service-state.test.js
 
-      - name: Test helper updater
-        run: bash tests/updater.test.sh
+      - name: Test installer and helper updater
+        run: bash tests/installer.test.sh && bash tests/updater.test.sh
 
       - name: Check Rust formatting
         run: cargo fmt --manifest-path backend/Cargo.toml --all -- --check

--- a/.github/workflows/helper-release.yml
+++ b/.github/workflows/helper-release.yml
@@ -1,0 +1,90 @@
+name: Helper release
+
+on:
+  push:
+    tags:
+      - "helper-v*"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    name: Build and publish helper
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
+        with:
+          toolchain: 1.97.1
+          components: rustfmt, clippy
+
+      - name: Verify helper tag and version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#helper-v}"
+          [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]
+          cargo_version=$(cargo metadata --no-deps --format-version 1 \
+            --manifest-path backend/Cargo.toml | jq -r '.packages[0].version')
+          [[ "$version" == "$cargo_version" ]]
+          [[ "$(git rev-list -n 1 "$GITHUB_REF_NAME")" == "$GITHUB_SHA" ]]
+
+      - name: Test frontend model
+        run: node tests/model.test.js && node tests/panel-state.test.js && node tests/service-state.test.js
+
+      - name: Test installer and helper updater
+        run: bash tests/installer.test.sh && bash tests/updater.test.sh
+
+      - name: Check Rust formatting
+        run: cargo fmt --manifest-path backend/Cargo.toml --all -- --check
+
+      - name: Lint Nearby helper
+        run: cargo clippy --all-targets --locked --manifest-path backend/Cargo.toml -- -D warnings
+
+      - name: Test Nearby helper
+        run: cargo test --locked --manifest-path backend/Cargo.toml
+
+      - name: Test vendored localsend-rs
+        run: cargo test --locked --manifest-path backend/vendor/localsend-rs/Cargo.toml --features https
+
+      - name: Build release helper
+        run: cargo build --release --locked --manifest-path backend/Cargo.toml
+
+      - name: Install license generator
+        run: cargo install cargo-about --locked --version 0.9.1 --features cli
+
+      - name: Assemble helper release
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#helper-v}"
+          asset="omarchy-nearby-helper-v${version}-linux-x86_64"
+          mkdir -p dist
+          install -m755 backend/target/release/omarchy-nearby-helper "dist/$asset"
+          (cd dist && sha256sum "$asset" > "$asset.sha256")
+          cargo about generate --manifest-path backend/Cargo.toml about.hbs > dist/THIRD_PARTY_LICENSES.html
+
+      - name: Attest helper
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: dist/omarchy-nearby-helper-v*-linux-x86_64
+
+      - name: Publish helper release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#helper-v}"
+          prerelease=()
+          [[ "$version" == *-* ]] && prerelease=(--prerelease)
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --verify-tag --generate-notes --title "$GITHUB_REF_NAME" "${prerelease[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,18 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the tagged source
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87
         with:
-          components: rustfmt
+          toolchain: 1.97.1
+          components: rustfmt, clippy
 
       - name: Verify release versions
         shell: bash
@@ -42,6 +43,9 @@ jobs:
 
       - name: Check Rust formatting
         run: cargo fmt --manifest-path backend/Cargo.toml --all -- --check
+
+      - name: Lint Nearby helper
+        run: cargo clippy --all-targets --locked --manifest-path backend/Cargo.toml -- -D warnings
 
       - name: Test Nearby helper
         run: cargo test --locked --manifest-path backend/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -38,8 +40,8 @@ jobs:
       - name: Test frontend model
         run: node tests/model.test.js && node tests/panel-state.test.js && node tests/service-state.test.js
 
-      - name: Test helper updater
-        run: bash tests/updater.test.sh
+      - name: Test installer and helper updater
+        run: bash tests/installer.test.sh && bash tests/updater.test.sh
 
       - name: Check Rust formatting
         run: cargo fmt --manifest-path backend/Cargo.toml --all -- --check
@@ -60,6 +62,8 @@ jobs:
         run: |
           file backend/target/release/omarchy-nearby-helper
           ldd backend/target/release/omarchy-nearby-helper
+          version_output=$(backend/target/release/omarchy-nearby-helper --version)
+          [[ "$version_output" == "omarchy-nearby-helper ${GITHUB_REF_NAME#v}" ]]
 
       - name: Install license generator
         run: cargo install cargo-about --locked --version 0.9.1 --features cli
@@ -73,6 +77,11 @@ jobs:
           install -m755 backend/target/release/omarchy-nearby-helper "dist/$asset"
           (cd dist && sha256sum "$asset" > "$asset.sha256")
           cargo about generate --manifest-path backend/Cargo.toml about.hbs > dist/THIRD_PARTY_LICENSES.html
+
+      - name: Attest release helper
+        uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
+        with:
+          subject-path: dist/omarchy-nearby-helper-*-linux-x86_64
 
       - name: Publish GitHub release
         env:

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,0 +1,47 @@
+name: Verify release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Stable release tag to verify (vX.Y.Z)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  attestations: read
+
+jobs:
+  verify:
+    name: Verify published helper
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify checksum, provenance and executable version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+          REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          platform="linux-x86_64"
+          asset="omarchy-nearby-helper-${RELEASE_TAG}-${platform}"
+          checksum="${asset}.sha256"
+          mkdir verify
+          gh release download "$RELEASE_TAG" --repo "$REPOSITORY" \
+            --dir verify --pattern "$asset" --pattern "$checksum"
+          [[ -f "verify/$asset" && ! -L "verify/$asset" ]]
+          (( $(stat -c %s -- "verify/$asset") <= 32 * 1024 * 1024 ))
+          (cd verify && sha256sum --check --strict "$checksum")
+          source_sha=$(gh api "repos/$REPOSITORY/commits/$RELEASE_TAG" --jq .sha)
+          gh attestation verify "verify/$asset" \
+            --repo "$REPOSITORY" \
+            --signer-workflow "$REPOSITORY/.github/workflows/release.yml" \
+            --source-digest "$source_sha" \
+            --source-ref "refs/tags/$RELEASE_TAG" \
+            --deny-self-hosted-runners
+          chmod 0755 "verify/$asset"
+          version_output=$("verify/$asset" --version)
+          [[ "$version_output" == "omarchy-nearby-helper ${RELEASE_TAG#v}" ]]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,8 +62,9 @@ Run commands from the repository root. Select checks by the changed behavior:
   model logic and inspect/evaluate QML source; they do not launch Quickshell.
 - Rust helper: run formatting, build checks, and helper tests. Vendor changes
   also require the separate vendored crate suite; helper tests do not replace it.
-- Helper updater: run the Bash suite below. It uses a stubbed `curl` to test
-  release lookup, checksum verification, replacement, and cleanup offline.
+- Installer or helper updater: run both Bash suites below. They use stubbed
+  external commands to test release lookup, download policy, checksum
+  verification, replacement, and cleanup offline.
 - Shell scripts: also run `bash -n` on the changed scripts. Syntax checks alone
   do not validate installation or updates on a live system.
 - Documentation only: check referenced paths and commands and run
@@ -76,6 +77,7 @@ when practical:
 node tests/model.test.js
 node tests/panel-state.test.js
 node tests/service-state.test.js
+bash tests/installer.test.sh
 bash tests/updater.test.sh
 cargo fmt --manifest-path backend/Cargo.toml --all -- --check
 cargo check --locked --manifest-path backend/Cargo.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
   without silently rotating valid key material.
 - Pin the Linux runner, Rust toolchain and CI actions, and reject Clippy
   warnings so local and hosted validation share a stable baseline.
+- Publish build-provenance attestations for release helpers and provide an
+  independent workflow that verifies checksum, source, signer and version.
+- Restrict installer and updater downloads to HTTPS, cap helper artifacts at
+  32 MiB, validate regular files and checksum targets, and stage outside the
+  live plugin checkout.
 
 ## 1.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Validate the persisted TLS certificate and key, derive and repair its
   fingerprint, reject unsafe identity files and replace updates atomically
   without silently rotating valid key material.
+- Pin the Linux runner, Rust toolchain and CI actions, and reject Clippy
+  warnings so local and hosted validation share a stable baseline.
 
 ## 1.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.5-dev
+
+- Bound helper commands, outgoing text and the live peer registry so oversized
+  local input or LAN identity churn cannot grow memory without limit.
+
 ## 1.1.4
 
 - Dim the Nearby bar icon while the receiver is disabled, while preserving the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Bound helper commands, outgoing text and the live peer registry so oversized
   local input or LAN identity churn cannot grow memory without limit.
+- Validate the persisted TLS certificate and key, derive and repair its
+  fingerprint, reject unsafe identity files and replace updates atomically
+  without silently rotating valid key material.
 
 ## 1.1.4
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ bash /tmp/omarchy-nearby-install.sh
 The installer selects a published release, installs the plugin at that exact tag,
 downloads its matching Linux x86_64 helper, verifies the SHA256, and enables
 `oma.nearby`. Nearby never requests administrator privileges. The installer does
-not install packages, require Rust, or compile anything locally.
+not install packages, require Rust, or compile anything locally. Helper downloads
+are HTTPS-only, limited to 32 MiB and staged outside the live plugin checkout.
 
 Install or reinstall a specific release with:
 
@@ -197,7 +198,7 @@ tracked. Nearby therefore states the oldest helper it can drive in
 `manifest.json`:
 
 ```json
-"minHelperVersion": "1.1.0"
+"minHelperVersion": "1.1.5-dev"
 ```
 
 A helper at or above that version keeps working after a source-only update, so
@@ -227,7 +228,13 @@ architecture, no network, or a development checkout with no release at all.
 Stable releases use tags such as `v1.0.3`. The tag, `manifest.json`, Rust package,
 and helper all carry the same version. Release helpers are built only by GitHub
 Actions and stored as GitHub Release assets with a SHA256 file and generated
-third-party license notices.
+third-party license notices. GitHub Actions also publishes a build-provenance
+attestation binding the helper to its repository, workflow, commit and tag.
+
+To independently verify a published helper, run the **Verify release** workflow
+and provide its exact `vX.Y.Z` tag. The workflow downloads the release again and
+checks its SHA256, attestation signer, source commit/ref, GitHub-hosted runner and
+reported `--version`; it does not reuse the build job that published the asset.
 
 Development on `main` uses the next SemVer prerelease, such as `1.0.4-dev`, as soon
 as it diverges from the preceding stable tag. `manifest.json` and
@@ -249,6 +256,13 @@ Backend tests:
 ```sh
 cargo test --manifest-path backend/Cargo.toml
 cargo test --manifest-path backend/vendor/localsend-rs/Cargo.toml --features https
+```
+
+Installer and updater tests:
+
+```sh
+bash tests/installer.test.sh
+bash tests/updater.test.sh
 ```
 
 A larger manual interoperability and robustness checklist is kept in

--- a/Service.qml
+++ b/Service.qml
@@ -110,6 +110,7 @@ Item {
     && Model.helperUpdateAvailable(pluginVersion, helperVersion)
   readonly property bool helperUpdateOffered: pluginVersion !== ""
     && (backendVersionMismatch || helperMissing || helperOutdated)
+  readonly property int maxOutgoingTextBytes: 1024 * 1024
   // One line, and the only place the versions are stated. The hero shows the
   // short status and the panel shows this; saying it in both is what made the
   // popup repeat itself three times over four lines.
@@ -228,6 +229,21 @@ Item {
   function send(command) {
     if (!backend.running) return
     backend.write(JSON.stringify(command) + "\n")
+  }
+  function utf8ByteLength(value) {
+    var text=String(value || "")
+    var bytes=0
+    for (var index=0; index<text.length; index++) {
+      var code=text.charCodeAt(index)
+      if (code<=0x7f) bytes++
+      else if (code<=0x7ff) bytes+=2
+      else if (code>=0xd800 && code<=0xdbff && index+1<text.length
+               && text.charCodeAt(index+1)>=0xdc00 && text.charCodeAt(index+1)<=0xdfff) {
+        bytes+=4
+        index++
+      } else bytes+=3
+    }
+    return bytes
   }
   function bindBackendRunning() {
     // Assigning a plain `true` here removes the declarative binding from
@@ -380,7 +396,15 @@ Item {
     pinError=""
     send(command)
   }
-  function beginOutgoing(pending) { if(pendingOutgoing||!backend.running)return; pendingOutgoing=pending; dispatchPendingOutgoing(null) }
+  function beginOutgoing(pending) {
+    if(pendingOutgoing||!backend.running)return
+    if(pending && pending.kind==="text" && utf8ByteLength(pending.text)>maxOutgoingTextBytes) {
+      failWith("Text is too large (maximum 1 MiB)")
+      return
+    }
+    pendingOutgoing=pending
+    dispatchPendingOutgoing(null)
+  }
   function retryWithPin(pin) {
     if (outgoingTransferId !== "") return
     var entered=String(pin || "")

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "omarchy-nearby-helper"
-version = "1.1.4"
+version = "1.1.5-dev"
 dependencies = [
  "anyhow",
  "localsend-rs",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1180,6 +1180,7 @@ name = "omarchy-nearby-helper"
 version = "1.1.5-dev"
 dependencies = [
  "anyhow",
+ "libc",
  "localsend-rs",
  "rustls",
  "rustls-pemfile",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -6,7 +6,10 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1"
+libc = "0.2"
 localsend-rs = { path = "vendor/localsend-rs", default-features = false, features = ["https"] }
+rustls = { version = "0.23.36", features = ["ring"] }
+rustls-pemfile = "2.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omarchy-nearby-helper"
-version = "1.1.4"
+version = "1.1.5-dev"
 edition = "2024"
 license = "MIT"
 

--- a/backend/src/identity.rs
+++ b/backend/src/identity.rs
@@ -1,0 +1,291 @@
+use anyhow::{Context, Result, anyhow};
+use localsend_rs::crypto::{TlsCertificate, generate_tls_certificate, sha256_from_bytes};
+use serde::{Deserialize, Serialize};
+use std::fs::{self, OpenOptions};
+use std::io::{ErrorKind, Read, Write};
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const MAX_IDENTITY_BYTES: usize = 128 * 1024;
+static TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Serialize, Deserialize)]
+struct StoredIdentity {
+    cert_pem: String,
+    key_pem: String,
+    fingerprint: String,
+}
+
+fn ensure_private_directory(path: &Path) -> Result<()> {
+    fs::create_dir_all(path).context("could not create Nearby state directory")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .context("could not protect Nearby state directory")?;
+    }
+    Ok(())
+}
+
+fn read_identity(path: &Path) -> Result<Option<Vec<u8>>> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).context("could not inspect TLS identity"),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(anyhow!("TLS identity must not be a symbolic link"));
+    }
+    if !metadata.is_file() {
+        return Err(anyhow!("TLS identity must be a regular file"));
+    }
+    if metadata.len() > MAX_IDENTITY_BYTES as u64 {
+        return Err(anyhow!("TLS identity exceeds 128 KiB"));
+    }
+
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = options.open(path).context("could not open TLS identity")?;
+    if !file
+        .metadata()
+        .context("could not inspect opened TLS identity")?
+        .is_file()
+    {
+        return Err(anyhow!("TLS identity must be a regular file"));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(fs::Permissions::from_mode(0o600))
+            .context("could not protect TLS identity")?;
+    }
+
+    let mut data = Vec::with_capacity(metadata.len() as usize);
+    file.take((MAX_IDENTITY_BYTES + 1) as u64)
+        .read_to_end(&mut data)
+        .context("could not read TLS identity")?;
+    if data.len() > MAX_IDENTITY_BYTES {
+        return Err(anyhow!("TLS identity exceeds 128 KiB"));
+    }
+    Ok(Some(data))
+}
+
+fn validate(stored: &StoredIdentity) -> Result<TlsCertificate> {
+    let mut cert_pem = stored.cert_pem.as_bytes();
+    let certificates = rustls_pemfile::certs(&mut cert_pem)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("could not parse TLS certificate")?;
+    let cert_der = certificates
+        .first()
+        .ok_or_else(|| anyhow!("TLS identity contains no certificate"))?
+        .as_ref()
+        .to_vec();
+
+    let mut key_pem = stored.key_pem.as_bytes();
+    let private_key = rustls_pemfile::private_key(&mut key_pem)
+        .context("could not parse TLS private key")?
+        .ok_or_else(|| anyhow!("TLS identity contains no private key"))?;
+
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+    rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certificates, private_key)
+        .context("TLS certificate and private key do not match")?;
+
+    let fingerprint = sha256_from_bytes(&cert_der);
+    Ok(TlsCertificate {
+        cert_pem: stored.cert_pem.clone(),
+        key_pem: stored.key_pem.clone(),
+        cert_der,
+        fingerprint,
+    })
+}
+
+fn save(path: &Path, certificate: &TlsCertificate) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("TLS identity path has no parent"))?;
+    let stored = StoredIdentity {
+        cert_pem: certificate.cert_pem.clone(),
+        key_pem: certificate.key_pem.clone(),
+        fingerprint: certificate.fingerprint.clone(),
+    };
+    let mut data =
+        serde_json::to_vec_pretty(&stored).context("could not serialize TLS identity")?;
+    data.push(b'\n');
+    if data.len() > MAX_IDENTITY_BYTES {
+        return Err(anyhow!("TLS identity exceeds 128 KiB"));
+    }
+
+    let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let temporary = parent.join(format!(
+        ".identity.json.tmp-{}-{sequence}",
+        std::process::id()
+    ));
+    let result = (|| -> Result<()> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&temporary)
+            .context("could not create temporary TLS identity")?;
+        file.write_all(&data)
+            .context("could not write TLS identity")?;
+        file.sync_all().context("could not flush TLS identity")?;
+        drop(file);
+        fs::rename(&temporary, path).context("could not replace TLS identity")?;
+        fs::File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .context("could not flush Nearby state directory")?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}
+
+pub fn load_or_create(state_dir: &Path) -> Result<TlsCertificate> {
+    ensure_private_directory(state_dir)?;
+    let path = state_dir.join("identity.json");
+    let Some(data) = read_identity(&path)? else {
+        let certificate = generate_tls_certificate().context("could not generate TLS identity")?;
+        save(&path, &certificate)?;
+        return Ok(certificate);
+    };
+
+    let stored: StoredIdentity =
+        serde_json::from_slice(&data).context("could not parse TLS identity")?;
+    let certificate = validate(&stored)?;
+    if stored.fingerprint != certificate.fingerprint {
+        save(&path, &certificate).context("could not repair TLS identity fingerprint")?;
+    }
+    Ok(certificate)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_directory(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "omarchy-nearby-identity-{name}-{}-{}",
+            std::process::id(),
+            TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    fn remove_test_directory(path: &Path) {
+        let _ = fs::remove_dir_all(path);
+    }
+
+    #[test]
+    fn identity_is_private_stable_and_has_derived_fingerprint() {
+        let directory = test_directory("stable");
+        let first = load_or_create(&directory).unwrap();
+        let second = load_or_create(&directory).unwrap();
+        assert_eq!(first.cert_pem, second.cert_pem);
+        assert_eq!(first.key_pem, second.key_pem);
+        assert_eq!(first.fingerprint, sha256_from_bytes(&first.cert_der));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&directory).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(directory.join("identity.json"))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+        remove_test_directory(&directory);
+    }
+
+    #[test]
+    fn wrong_fingerprint_is_repaired_without_rotating_key_material() {
+        let directory = test_directory("fingerprint");
+        let original = load_or_create(&directory).unwrap();
+        let path = directory.join("identity.json");
+        let mut stored: StoredIdentity = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        stored.fingerprint = "wrong".into();
+        fs::write(&path, serde_json::to_vec_pretty(&stored).unwrap()).unwrap();
+
+        let repaired = load_or_create(&directory).unwrap();
+        assert_eq!(repaired.cert_pem, original.cert_pem);
+        assert_eq!(repaired.key_pem, original.key_pem);
+        assert_eq!(repaired.fingerprint, original.fingerprint);
+        let persisted: StoredIdentity = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(persisted.fingerprint, original.fingerprint);
+        remove_test_directory(&directory);
+    }
+
+    #[test]
+    fn corrupt_oversized_and_non_regular_identities_fail_closed() {
+        for (name, data) in [
+            ("corrupt", b"not json".to_vec()),
+            ("oversized", vec![b'x'; MAX_IDENTITY_BYTES + 1]),
+        ] {
+            let directory = test_directory(name);
+            fs::create_dir_all(&directory).unwrap();
+            fs::write(directory.join("identity.json"), data).unwrap();
+            assert!(load_or_create(&directory).is_err());
+            remove_test_directory(&directory);
+        }
+
+        let directory = test_directory("directory");
+        fs::create_dir_all(directory.join("identity.json")).unwrap();
+        assert!(load_or_create(&directory).is_err());
+        remove_test_directory(&directory);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symbolic_link_identity_is_rejected_without_touching_its_target() {
+        use std::os::unix::fs::symlink;
+
+        let directory = test_directory("symlink");
+        fs::create_dir_all(&directory).unwrap();
+        let target = directory.join("target");
+        fs::write(&target, b"keep me").unwrap();
+        symlink(&target, directory.join("identity.json")).unwrap();
+        assert!(load_or_create(&directory).is_err());
+        assert_eq!(fs::read(&target).unwrap(), b"keep me");
+        remove_test_directory(&directory);
+    }
+
+    #[test]
+    fn mismatched_certificate_and_key_fail_without_rotation() {
+        let directory = test_directory("mismatch");
+        fs::create_dir_all(&directory).unwrap();
+        let certificate = generate_tls_certificate().unwrap();
+        let other = generate_tls_certificate().unwrap();
+        let stored = StoredIdentity {
+            cert_pem: certificate.cert_pem,
+            key_pem: other.key_pem,
+            fingerprint: certificate.fingerprint,
+        };
+        let path = directory.join("identity.json");
+        let bytes = serde_json::to_vec_pretty(&stored).unwrap();
+        fs::write(&path, &bytes).unwrap();
+        assert!(load_or_create(&directory).is_err());
+        assert_eq!(fs::read(&path).unwrap(), bytes);
+        remove_test_directory(&directory);
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -12,13 +12,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
-use std::io::Write;
+use std::io::{self, Write};
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
 use tokio::sync::{mpsc, oneshot};
 
 mod settings;
@@ -30,9 +30,82 @@ const MAX_SUBNET_ADDRESSES: u32 = 1024;
 const STALE_PARTIAL_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 const NEARBY_PORT: u16 = 53317;
 const MAX_OUTGOING_PIN_BYTES: usize = 4096;
+const MAX_COMMAND_LINE_BYTES: usize = 2 * 1024 * 1024;
+const MAX_TEXT_BYTES: usize = 1024 * 1024;
+const MAX_PEERS: usize = 256;
+
+#[derive(Debug, PartialEq, Eq)]
+enum CommandLine {
+    Line(Vec<u8>),
+    TooLong,
+}
+
+struct BoundedLineReader<R> {
+    inner: R,
+    buffer: Vec<u8>,
+    oversized: bool,
+    max_bytes: usize,
+}
+
+impl<R: AsyncBufRead + Unpin> BoundedLineReader<R> {
+    fn new(inner: R, max_bytes: usize) -> Self {
+        Self {
+            inner,
+            buffer: Vec::new(),
+            oversized: false,
+            max_bytes,
+        }
+    }
+
+    async fn next_line(&mut self) -> io::Result<Option<CommandLine>> {
+        loop {
+            let available = self.inner.fill_buf().await?;
+            if available.is_empty() {
+                if self.buffer.is_empty() && !self.oversized {
+                    return Ok(None);
+                }
+                let result = if self.oversized {
+                    CommandLine::TooLong
+                } else {
+                    CommandLine::Line(std::mem::take(&mut self.buffer))
+                };
+                self.oversized = false;
+                return Ok(Some(result));
+            }
+
+            let newline = available.iter().position(|byte| *byte == b'\n');
+            let consumed = newline.map_or(available.len(), |index| index + 1);
+            let content = &available[..newline.unwrap_or(available.len())];
+            if !self.oversized {
+                let remaining = self.max_bytes.saturating_sub(self.buffer.len());
+                if content.len() <= remaining {
+                    self.buffer.extend_from_slice(content);
+                } else {
+                    self.oversized = true;
+                }
+            }
+            self.inner.consume(consumed);
+
+            if newline.is_some() {
+                let result = if self.oversized {
+                    CommandLine::TooLong
+                } else {
+                    CommandLine::Line(std::mem::take(&mut self.buffer))
+                };
+                self.buffer.clear();
+                self.oversized = false;
+                return Ok(Some(result));
+            }
+        }
+    }
+}
 
 fn valid_outgoing_pin(pin: Option<&str>) -> bool {
     pin.is_none_or(|value| !value.is_empty() && value.len() <= MAX_OUTGOING_PIN_BYTES)
+}
+
+fn outgoing_text_within_limit(text: &str) -> bool {
+    text.len() <= MAX_TEXT_BYTES
 }
 
 /// True when a failure was caused by the LocalSend port already being bound.
@@ -183,13 +256,31 @@ fn record_peer(registry: &Arc<Mutex<HashMap<String, Peer>>>, device: DeviceInfo)
     if device.fingerprint.is_empty() || device.alias.is_empty() {
         return;
     }
-    registry.lock().unwrap().insert(
-        device.fingerprint.clone(),
-        Peer {
-            device: device.clone(),
-            last_seen: Instant::now(),
-        },
-    );
+    {
+        let mut peers = registry.lock().unwrap();
+        peers.retain(|_, peer| peer.last_seen.elapsed() <= PEER_TTL);
+        if !peers.contains_key(&device.fingerprint)
+            && peers.len() >= MAX_PEERS
+            && let Some(oldest) = peers
+                .iter()
+                .min_by(|(fingerprint_a, peer_a), (fingerprint_b, peer_b)| {
+                    peer_a
+                        .last_seen
+                        .cmp(&peer_b.last_seen)
+                        .then_with(|| fingerprint_a.cmp(fingerprint_b))
+                })
+                .map(|(fingerprint, _)| fingerprint.clone())
+        {
+            peers.remove(&oldest);
+        }
+        peers.insert(
+            device.fingerprint.clone(),
+            Peer {
+                device: device.clone(),
+                last_seen: Instant::now(),
+            },
+        );
+    }
     eprintln!("peer registered: {}", valid_remote_text(&device.alias, 128));
     emit(json!({"event":"device","device":event_device(&device)}));
 }
@@ -961,7 +1052,8 @@ async fn main() -> Result<()> {
             }
         }
     });
-    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    let mut lines =
+        BoundedLineReader::new(BufReader::new(tokio::io::stdin()), MAX_COMMAND_LINE_BYTES);
     let mut discovery: Option<DiscoveryControl> = None;
     let mut outgoing: Option<OutgoingControl> = None;
     let (out_done_tx, mut out_done_rx) = mpsc::unbounded_channel::<OutgoingDone>();
@@ -985,7 +1077,8 @@ async fn main() -> Result<()> {
             },
             line = lines.next_line() => {
                 let Some(line)=line? else {break};
-                let command: Command = match serde_json::from_str(&line) { Ok(v)=>v, Err(_)=>{emit(json!({"event":"error","message":"Invalid backend command"}));continue;} };
+                let CommandLine::Line(line)=line else {emit(json!({"event":"error","message":"Backend command exceeds 2 MiB limit"}));continue;};
+                let command: Command = match serde_json::from_slice(&line) { Ok(v)=>v, Err(_)=>{emit(json!({"event":"error","message":"Invalid backend command"}));continue;} };
                 match command {
                     Command::DiscoveryStart { force_full } => {
                         if force_full && let Some(control)=discovery.take(){let _=control.stop.send(());}
@@ -1010,6 +1103,7 @@ async fn main() -> Result<()> {
                     }
                     Command::SendText { transfer_id,device,text,pin } => {
                         if outgoing.is_some(){emit(json!({"event":"outgoing_failed","transferId":transfer_id,"message":"Another transfer is already active"}));continue;}
+                        if !outgoing_text_within_limit(&text){emit(json!({"event":"outgoing_failed","transferId":transfer_id,"message":"Text is too large (maximum 1 MiB)"}));continue;}
                         if !valid_outgoing_pin(pin.as_deref()){emit(json!({"event":"outgoing_failed","transferId":transfer_id,"message":"Invalid receiver PIN"}));continue;}
                         let (tx,rx)=oneshot::channel(); outgoing=Some(OutgoingControl{id:transfer_id.clone(),cancel:tx});
                         let (identity,certificate,done)=(identity.clone(),certificate.clone(),out_done_tx.clone()); tokio::spawn(async move {
@@ -1138,6 +1232,44 @@ mod tests {
     }
 
     #[test]
+    fn outgoing_text_limit_counts_utf8_bytes() {
+        assert!(outgoing_text_within_limit(&"x".repeat(MAX_TEXT_BYTES)));
+        assert!(!outgoing_text_within_limit(&"x".repeat(MAX_TEXT_BYTES + 1)));
+        assert!(outgoing_text_within_limit(&"ñ".repeat(MAX_TEXT_BYTES / 2)));
+        assert!(!outgoing_text_within_limit(
+            &"ñ".repeat(MAX_TEXT_BYTES / 2 + 1)
+        ));
+    }
+
+    #[tokio::test]
+    async fn bounded_command_reader_accepts_the_limit_and_recovers_after_rejection() {
+        let mut input = vec![b' '; MAX_COMMAND_LINE_BYTES];
+        input.push(b'\n');
+        input.extend(std::iter::repeat_n(b'x', MAX_COMMAND_LINE_BYTES + 1));
+        input.push(b'\n');
+        input.extend_from_slice(b"{\"command\":\"shutdown\"}\n");
+        let mut reader =
+            BoundedLineReader::new(BufReader::new(input.as_slice()), MAX_COMMAND_LINE_BYTES);
+
+        assert!(matches!(
+            reader.next_line().await.unwrap(),
+            Some(CommandLine::Line(line)) if line.len() == MAX_COMMAND_LINE_BYTES
+        ));
+        assert_eq!(
+            reader.next_line().await.unwrap(),
+            Some(CommandLine::TooLong)
+        );
+        let Some(CommandLine::Line(line)) = reader.next_line().await.unwrap() else {
+            panic!("reader did not recover after an oversized command");
+        };
+        assert!(matches!(
+            serde_json::from_slice::<Command>(&line).unwrap(),
+            Command::Shutdown
+        ));
+        assert_eq!(reader.next_line().await.unwrap(), None);
+    }
+
+    #[test]
     fn peer_registry_keeps_valid_and_expires_stale() {
         let d = DeviceInfo::new("Phone".into(), 53317, Protocol::Http);
         let key = d.fingerprint.clone();
@@ -1152,6 +1284,38 @@ mod tests {
         map.lock().unwrap().get_mut(&key).unwrap().last_seen =
             Instant::now() - PEER_TTL - Duration::from_secs(1);
         assert!(expire_and_snapshot(&map).is_empty());
+    }
+
+    #[test]
+    fn peer_registry_is_bounded_and_evicts_deterministically() {
+        let same_last_seen = Instant::now() - Duration::from_secs(1);
+        let registry = Arc::new(Mutex::new(HashMap::new()));
+        for index in 0..MAX_PEERS {
+            let mut device = DeviceInfo::new(format!("Peer {index}"), 53317, Protocol::Http);
+            device.fingerprint = format!("peer-{index:03}");
+            registry.lock().unwrap().insert(
+                device.fingerprint.clone(),
+                Peer {
+                    device,
+                    last_seen: same_last_seen,
+                },
+            );
+        }
+
+        let mut refreshed = DeviceInfo::new("Refreshed".into(), 53317, Protocol::Http);
+        refreshed.fingerprint = "peer-001".into();
+        record_peer(&registry, refreshed);
+        assert_eq!(registry.lock().unwrap().len(), MAX_PEERS);
+        assert!(registry.lock().unwrap().contains_key("peer-000"));
+
+        let mut newcomer = DeviceInfo::new("New peer".into(), 53317, Protocol::Http);
+        newcomer.fingerprint = "peer-new".into();
+        record_peer(&registry, newcomer);
+        let peers = registry.lock().unwrap();
+        assert_eq!(peers.len(), MAX_PEERS);
+        assert!(!peers.contains_key("peer-000"));
+        assert!(peers.contains_key("peer-001"));
+        assert!(peers.contains_key("peer-new"));
     }
     #[test]
     fn xdg_downloads_parsing_falls_back() {

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -877,6 +877,10 @@ fn configure_receiver_pin(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    if std::env::args_os().nth(1).as_deref() == Some(std::ffi::OsStr::new("--version")) {
+        println!("omarchy-nearby-helper {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
     let home = PathBuf::from(std::env::var("HOME").context("HOME is not set")?);
     let state_dir = settings::state_dir(&home);
     let settings_path = state_dir.join("settings.json");

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -300,7 +300,6 @@ fn http_scan_targets(interfaces: Vec<(Ipv4Addr, Ipv4Addr)>) -> (Vec<String>, Vec
     let usable: BTreeSet<Ipv4Addr> = interfaces
         .iter()
         .map(|(ip, _)| *ip)
-        .into_iter()
         .filter(|ip| {
             !ip.is_unspecified()
                 && !ip.is_loopback()
@@ -611,6 +610,10 @@ async fn start_active_discovery(
     }
 }
 
+// Identity, target, payload, authorization and cancellation are independent
+// parts of one transfer operation; grouping them would only move this contract
+// into a single-use parameter struct.
+#[allow(clippy::too_many_arguments)]
 async fn send_payload(
     transfer_id: String,
     identity: DeviceInfo,
@@ -1081,7 +1084,7 @@ async fn main() -> Result<()> {
                             let _=done.send(OutgoingDone{id:transfer_id,event});
                         });
                     }
-                    Command::CancelOutgoing { transfer_id } => if outgoing.as_ref().is_some_and(|o|o.id==transfer_id) { if let Some(control)=outgoing.take(){let _=control.cancel.send(());} },
+                    Command::CancelOutgoing { transfer_id } => if outgoing.as_ref().is_some_and(|o|o.id==transfer_id) && let Some(control)=outgoing.take(){let _=control.cancel.send(());},
                     Command::SetIncomingPin { pin } => {
                         match update_incoming_pin(&mut server,&settings_path,&mut receiver_settings,Some(pin)).await {
                             Ok(())=>emit(json!({"event":"incoming_pin_state","enabled":true})),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,13 +2,13 @@ use anyhow::{Context, Result, anyhow};
 use localsend_rs::LocalSendServer;
 use localsend_rs::client::{LocalSendClient, ProgressCallback, TlsTrustPolicy};
 use localsend_rs::core::build_file_metadata;
-use localsend_rs::crypto::{TlsCertificate, generate_tls_certificate};
+use localsend_rs::crypto::TlsCertificate;
 use localsend_rs::discovery::{Discovery, HttpDiscovery, MulticastDiscovery};
 use localsend_rs::error::LocalSendError;
 use localsend_rs::protocol::types::FileMetadataDetails;
 use localsend_rs::protocol::{DeviceInfo, FileId, FileMetadata, Protocol};
 use localsend_rs::server::{LocalSendServerBuilder, PendingRequest, ServerEvent};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::future::Future;
@@ -21,6 +21,7 @@ use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, BufReader};
 use tokio::sync::{mpsc, oneshot};
 
+mod identity;
 mod settings;
 
 const PEER_TTL: Duration = Duration::from_secs(90);
@@ -199,13 +200,6 @@ fn pin_failure_outcome(pin_was_provided: bool) -> SendPayloadOutcome {
 struct Peer {
     device: DeviceInfo,
     last_seen: Instant,
-}
-
-#[derive(Serialize, Deserialize)]
-struct StoredIdentity {
-    cert_pem: String,
-    key_pem: String,
-    fingerprint: String,
 }
 
 fn emit(value: Value) {
@@ -820,35 +814,6 @@ async fn cleanup_stale_partial_files(directory: &Path, minimum_age: Duration) ->
     Ok(removed)
 }
 
-fn load_identity(home: &Path) -> Result<TlsCertificate> {
-    let state_dir = settings::state_dir(home);
-    std::fs::create_dir_all(&state_dir)?;
-    let path = state_dir.join("identity.json");
-    if let Ok(data) = std::fs::read(&path) {
-        if let Ok(stored) = serde_json::from_slice::<StoredIdentity>(&data) {
-            return Ok(TlsCertificate {
-                cert_pem: stored.cert_pem,
-                key_pem: stored.key_pem,
-                cert_der: Vec::new(),
-                fingerprint: stored.fingerprint,
-            });
-        }
-    }
-    let cert = generate_tls_certificate()?;
-    let stored = StoredIdentity {
-        cert_pem: cert.cert_pem.clone(),
-        key_pem: cert.key_pem.clone(),
-        fingerprint: cert.fingerprint.clone(),
-    };
-    std::fs::write(&path, serde_json::to_vec_pretty(&stored)?)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
-    }
-    Ok(cert)
-}
-
 fn resolve_device_alias() -> String {
     resolve_device_alias_from(std::env::var("HOSTNAME").ok(), || {
         std::fs::read_to_string("/proc/sys/kernel/hostname")
@@ -938,7 +903,7 @@ async fn main() -> Result<()> {
         Err(error) => eprintln!("could not clean stale Nearby partial files: {error}"),
     }
     let alias = resolve_device_alias();
-    let certificate = load_identity(&home).context("TLS identity unavailable")?;
+    let certificate = identity::load_or_create(&state_dir).context("TLS identity unavailable")?;
     let mut builder = LocalSendServer::builder()
         .alias(alias)
         .port(NEARBY_PORT)
@@ -1148,6 +1113,7 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use localsend_rs::crypto::generate_tls_certificate;
 
     #[test]
     fn device_alias_prefers_environment_hostname() {

--- a/bin/nearby-update-helper
+++ b/bin/nearby-update-helper
@@ -23,6 +23,9 @@ set -uo pipefail
 plugin_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 readonly plugin_dir
 readonly repository="jfg96/omarchy-nearby"
+readonly max_helper_bytes=$((32 * 1024 * 1024))
+readonly max_metadata_bytes=$((1024 * 1024))
+readonly max_checksum_bytes=4096
 
 emit() { jq -nc "$@" 2>/dev/null || printf '{"event":"failed","message":"could not report progress"}\n'; }
 step() { emit --arg m "$1" '{event:"step",message:$m}'; }
@@ -32,12 +35,43 @@ fail() {
 }
 
 # jq builds every line above, so a missing jq cannot be reported as JSON.
-for command_name in curl jq sha256sum; do
+for command_name in curl jq sha256sum stat; do
   if ! command -v "$command_name" >/dev/null 2>&1; then
     printf '{"event":"failed","message":"required command not found: %s"}\n' "$command_name"
     exit 1
   fi
 done
+
+download_file() {
+  local url="$1" destination="$2" limit="$3" label="$4" status size
+  [[ $url == https://* ]] || fail "$label URL is not HTTPS"
+  curl --fail --location --silent --show-error \
+    --proto '=https' --proto-redir '=https' \
+    --connect-timeout 10 --max-time 300 --max-filesize "$limit" \
+    --output "$destination" "$url"
+  status=$?
+  if (( status != 0 )); then
+    (( status == 63 )) && fail "$label exceeds its download limit"
+    fail "$label download did not finish. Check your connection and try again."
+  fi
+  [[ -f $destination && ! -L $destination ]] || fail "$label is not a regular file"
+  size=$(stat -c %s -- "$destination") || fail "Could not inspect downloaded $label"
+  (( size > 0 && size <= limit )) || fail "$label exceeds its download limit"
+}
+
+verify_checksum() {
+  local checksum_file="$1" asset_file="$2" asset_name="$3"
+  local expected target extra actual
+  read -r expected target extra <"$checksum_file" \
+    || fail "The downloaded checksum is malformed"
+  target=${target#\*}
+  [[ $expected =~ ^[[:xdigit:]]{64}$ && $target == "$asset_name" && -z ${extra:-} ]] \
+    || fail "The downloaded checksum is malformed"
+  actual=$(sha256sum "$asset_file") || fail "Could not hash the downloaded helper"
+  actual=${actual%% *}
+  [[ ${actual,,} == ${expected,,} ]] \
+    || fail "The downloaded helper failed its SHA256 check and was discarded"
+}
 
 case "$(uname -m)" in
 x86_64 | amd64) platform="linux-x86_64" ;;
@@ -82,10 +116,18 @@ trap cleanup EXIT
 step "Looking up Nearby $tag…"
 release_file="$stage_dir/release.json"
 http_status=$(curl --location --silent --output "$release_file" --write-out '%{http_code}' \
+  --proto '=https' --proto-redir '=https' --connect-timeout 10 --max-time 30 \
+  --max-filesize "$max_metadata_bytes" \
   "https://api.github.com/repos/${repository}/releases/tags/${tag}")
 curl_status=$?
-(( curl_status == 0 )) \
-  || fail "Could not reach GitHub (curl error $curl_status). Check your connection and try again."
+if (( curl_status != 0 )); then
+  (( curl_status == 63 )) && fail "GitHub release metadata exceeds its download limit"
+  fail "Could not reach GitHub (curl error $curl_status). Check your connection and try again."
+fi
+[[ -f $release_file && ! -L $release_file ]] || fail "GitHub release metadata is not a regular file"
+release_size=$(stat -c %s -- "$release_file") || fail "Could not inspect GitHub release metadata"
+(( release_size > 0 && release_size <= max_metadata_bytes )) \
+  || fail "GitHub release metadata exceeds its download limit"
 
 case "$http_status" in
 200) ;;
@@ -109,14 +151,11 @@ checksum_url=$(jq -r --arg name "$checksum_name" \
   || fail "Release $tag publishes no $platform helper. Build it with ./build.sh."
 
 step "Downloading helper $tag…"
-curl --fail --location --silent --show-error --output "$stage_dir/$asset_name" "$asset_url" \
-  || fail "The $tag helper download did not finish. Check your connection and try again."
-curl --fail --location --silent --show-error --output "$stage_dir/$checksum_name" "$checksum_url" \
-  || fail "The $tag checksum download did not finish. Check your connection and try again."
+download_file "$asset_url" "$stage_dir/$asset_name" "$max_helper_bytes" "The $tag helper"
+download_file "$checksum_url" "$stage_dir/$checksum_name" "$max_checksum_bytes" "The $tag checksum"
 
 step "Verifying checksum…"
-(cd "$stage_dir" && sha256sum --check --strict "$checksum_name" >/dev/null 2>&1) \
-  || fail "The downloaded helper failed its SHA256 check and was discarded"
+verify_checksum "$stage_dir/$checksum_name" "$stage_dir/$asset_name" "$asset_name"
 
 chmod 0755 "$stage_dir/$asset_name" || fail "Could not make the helper executable"
 

--- a/install.sh
+++ b/install.sh
@@ -6,15 +6,50 @@ readonly repository="jfg96/omarchy-nearby"
 readonly repository_url="https://github.com/${repository}.git"
 readonly plugins_dir="${HOME}/.config/omarchy/plugins"
 readonly plugin_dir="${plugins_dir}/${plugin_id}"
+readonly max_helper_bytes=$((32 * 1024 * 1024))
+readonly max_metadata_bytes=$((1024 * 1024))
+readonly max_checksum_bytes=4096
 
 fail() {
   echo "nearby-install: $*" >&2
   exit 1
 }
 
-for command_name in curl git jq omarchy omarchy-shell sha256sum; do
+for command_name in curl git jq omarchy omarchy-shell sha256sum stat; do
   command -v "$command_name" >/dev/null 2>&1 || fail "required command not found: $command_name"
 done
+
+download_file() {
+  local url="$1" destination="$2" limit="$3" label="$4" status size
+  [[ $url == https://* ]] || fail "$label URL is not HTTPS"
+  if curl --fail --location --silent --show-error \
+    --proto '=https' --proto-redir '=https' \
+    --connect-timeout 10 --max-time 300 --max-filesize "$limit" \
+    --output "$destination" "$url"; then
+    :
+  else
+    status=$?
+    (( status == 63 )) && fail "$label exceeds its download limit"
+    fail "$label download did not finish"
+  fi
+  [[ -f $destination && ! -L $destination ]] || fail "$label is not a regular file"
+  size=$(stat -c %s -- "$destination") || fail "could not inspect downloaded $label"
+  (( size > 0 && size <= limit )) || fail "$label exceeds its download limit"
+}
+
+verify_checksum() {
+  local checksum_file="$1" asset_file="$2" asset_name="$3"
+  local expected target extra actual
+  read -r expected target extra <"$checksum_file" \
+    || fail "downloaded checksum is malformed"
+  target=${target#\*}
+  [[ $expected =~ ^[[:xdigit:]]{64}$ && $target == "$asset_name" && -z ${extra:-} ]] \
+    || fail "downloaded checksum is malformed"
+  actual=$(sha256sum "$asset_file") || fail "could not hash downloaded helper"
+  actual=${actual%% *}
+  [[ ${actual,,} == ${expected,,} ]] \
+    || fail "downloaded helper failed its SHA256 check and was discarded"
+}
 
 [[ $(uname -s) == "Linux" ]] || fail "prebuilt helpers are supported only on Linux"
 case "$(uname -m)" in
@@ -34,8 +69,13 @@ else
   release_url="https://api.github.com/repos/${repository}/releases/latest"
 fi
 
-release_json=$(curl --fail --location --silent --show-error "$release_url") \
+release_json=$(curl --fail --location --silent --show-error \
+  --proto '=https' --proto-redir '=https' \
+  --connect-timeout 10 --max-time 30 --max-filesize "$max_metadata_bytes" \
+  "$release_url") \
   || fail "could not resolve the requested GitHub release"
+(( ${#release_json} > 0 && ${#release_json} <= max_metadata_bytes )) \
+  || fail "GitHub release metadata exceeds its download limit"
 tag=$(jq -r '.tag_name // empty' <<<"$release_json")
 [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "GitHub did not return a stable SemVer release"
 [[ -z $requested_tag || $tag == "$requested_tag" ]] || fail "GitHub returned release $tag instead of $requested_tag"
@@ -47,6 +87,8 @@ checksum_name="${asset_name}.sha256"
 asset_url=$(jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .browser_download_url' <<<"$release_json")
 checksum_url=$(jq -r --arg name "$checksum_name" '.assets[] | select(.name == $name) | .browser_download_url' <<<"$release_json")
 [[ -n $asset_url && -n $checksum_url ]] || fail "release $tag does not contain the expected $platform helper and checksum"
+[[ $asset_url == https://* && $checksum_url == https://* ]] \
+  || fail "release $tag returned a non-HTTPS asset URL"
 
 if [[ ! -d $plugin_dir ]]; then
   omarchy plugin add "$repository_url" --yes
@@ -84,18 +126,18 @@ cargo_version=$(awk '
   || fail "release version mismatch: tag=$version manifest=$manifest_version cargo=$cargo_version"
 
 mkdir -p "$plugin_dir/bin"
-stage_dir=$(mktemp -d "$plugin_dir/bin/.install.XXXXXX")
+cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/omarchy-nearby"
+mkdir -p "$cache_root"
+stage_dir=$(mktemp -d "$cache_root/install.XXXXXX")
 cleanup() { rm -rf -- "$stage_dir"; }
 trap cleanup EXIT
 
-curl --fail --location --silent --show-error --output "$stage_dir/$asset_name" "$asset_url"
-curl --fail --location --silent --show-error --output "$stage_dir/$checksum_name" "$checksum_url"
-(
-  cd "$stage_dir"
-  sha256sum --check --strict "$checksum_name"
-)
+download_file "$asset_url" "$stage_dir/$asset_name" "$max_helper_bytes" "helper $tag"
+download_file "$checksum_url" "$stage_dir/$checksum_name" "$max_checksum_bytes" "checksum $tag"
+verify_checksum "$stage_dir/$checksum_name" "$stage_dir/$asset_name" "$asset_name"
 chmod 0755 "$stage_dir/$asset_name"
-mv -- "$stage_dir/$asset_name" "$plugin_dir/bin/omarchy-nearby-helper"
+mv -- "$stage_dir/$asset_name" "$plugin_dir/bin/omarchy-nearby-helper" \
+  || fail "could not atomically install the helper"
 
 omarchy-shell shell rescanPlugins >/dev/null
 omarchy plugin enable "$plugin_id"

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "id": "oma.nearby",
   "name": "Nearby",
-  "version": "1.1.4",
-  "minHelperVersion": "1.1.0",
+  "version": "1.1.5-dev",
+  "minHelperVersion": "1.1.5-dev",
   "author": "jfg96",
   "description": "Native nearby sharing compatible with the LocalSend protocol",
   "kinds": [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.1"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/tests/installer.test.sh
+++ b/tests/installer.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+# install.sh, offline. External commands are stubbed so release resolution,
+# download policy and replacement can be exercised without touching a real
+# Omarchy installation or network.
+
+set -uo pipefail
+
+tests_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+readonly installer_source="$tests_dir/../install.sh"
+failures=0
+current=""
+
+announce() { current="$1"; }
+report() {
+  echo "  FAIL: $current" >&2
+  echo "        $1" >&2
+  failures=$((failures + 1))
+}
+assert_eq() { [[ $1 == "$2" ]] || report "expected '$2', got '$1'"; }
+assert_contains() { [[ $1 == *"$2"* ]] || report "expected output to contain '$2', got: $1"; }
+
+setup() {
+  sandbox=$(mktemp -d "${TMPDIR:-/tmp}/nearby-installer-test.XXXXXX")
+  fake_home="$sandbox/home"
+  plugin="$fake_home/.config/omarchy/plugins/oma.nearby"
+  stub_bin="$sandbox/stub-bin"
+  mkdir -p "$fake_home" "$stub_bin" "$sandbox/cache" "$sandbox/served"
+
+  platform="linux-$(uname -m)"
+  [[ $platform == "linux-amd64" ]] && platform="linux-x86_64"
+  asset_name="omarchy-nearby-helper-v1.1.0-${platform}"
+  printf 'new helper 1.1.0\n' >"$sandbox/served/$asset_name"
+  (cd "$sandbox/served" && sha256sum "$asset_name" >"$asset_name.sha256")
+
+  export FAKE_PLUGIN_DIR="$plugin"
+  export FAKE_ASSET_FILE="$sandbox/served/$asset_name"
+  export FAKE_CHECKSUM_FILE="$sandbox/served/$asset_name.sha256"
+  export FAKE_RELEASE_JSON="$sandbox/release.json"
+  release_json "https://example.invalid/$asset_name"
+
+  cat >"$stub_bin/curl" <<'STUB'
+#!/usr/bin/env bash
+output=""
+url=""
+previous=""
+for argument in "$@"; do
+  [[ $previous == --output ]] && output="$argument"
+  [[ $argument == http* ]] && url="$argument"
+  previous="$argument"
+done
+if [[ $url == *api.github.com* ]]; then
+  cat "$FAKE_RELEASE_JSON"
+elif [[ $url == *.sha256 ]]; then
+  cp "$FAKE_CHECKSUM_FILE" "$output"
+else
+  cp "$FAKE_ASSET_FILE" "$output"
+fi
+STUB
+
+  cat >"$stub_bin/omarchy" <<'STUB'
+#!/usr/bin/env bash
+if [[ ${1:-} == plugin && ${2:-} == add ]]; then
+  mkdir -p "$FAKE_PLUGIN_DIR/.git" "$FAKE_PLUGIN_DIR/bin" "$FAKE_PLUGIN_DIR/backend"
+  printf '{"id":"oma.nearby","version":"1.1.0"}\n' >"$FAKE_PLUGIN_DIR/manifest.json"
+  printf '[package]\nname = "omarchy-nearby-helper"\nversion = "1.1.0"\n' >"$FAKE_PLUGIN_DIR/backend/Cargo.toml"
+  printf 'old helper\n' >"$FAKE_PLUGIN_DIR/bin/omarchy-nearby-helper"
+fi
+exit 0
+STUB
+
+  cat >"$stub_bin/git" <<'STUB'
+#!/usr/bin/env bash
+case " $* " in
+  *" remote get-url origin "*) printf 'https://github.com/jfg96/omarchy-nearby.git\n' ;;
+  *" status --porcelain "*) ;;
+  *" rev-parse "*) printf 'test-commit\n' ;;
+esac
+exit 0
+STUB
+
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$stub_bin/omarchy-shell"
+  chmod 0755 "$stub_bin"/*
+}
+
+release_json() {
+  local asset_url="$1"
+  jq -n --arg asset "$asset_name" --arg url "$asset_url" '{
+    tag_name: "v1.1.0", draft: false, prerelease: false,
+    assets: [
+      {name: $asset, browser_download_url: $url},
+      {name: ($asset + ".sha256"), browser_download_url: ($url + ".sha256")}
+    ]
+  }' >"$FAKE_RELEASE_JSON"
+}
+
+run_installer() {
+  HOME="$fake_home" XDG_CACHE_HOME="$sandbox/cache" PATH="$stub_bin:$PATH" \
+    bash "$installer_source" v1.1.0 2>&1
+}
+
+installed_helper() { cat "$plugin/bin/omarchy-nearby-helper"; }
+teardown() { [[ -n ${sandbox:-} && -d $sandbox ]] && rm -rf -- "$sandbox"; }
+
+announce "success installs the verified helper from staging outside the plugin"
+setup
+output=$(run_installer); status=$?
+assert_eq "$status" "0"
+assert_contains "$output" "Nearby 1.1.0 installed"
+assert_eq "$(installed_helper)" "new helper 1.1.0"
+assert_eq "$(find "$sandbox/cache" -name 'install.*' | wc -l)" "0"
+assert_eq "$(find "$plugin/bin" -name '.install.*' | wc -l)" "0"
+teardown
+
+announce "an oversized helper leaves the old helper intact"
+setup
+truncate -s $((32 * 1024 * 1024 + 1)) "$FAKE_ASSET_FILE"
+output=$(run_installer); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "exceeds its download limit"
+assert_eq "$(installed_helper)" "old helper"
+teardown
+
+announce "a non-HTTPS asset URL is refused"
+setup
+release_json "http://example.invalid/$asset_name"
+output=$(run_installer); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "non-HTTPS asset URL"
+[[ ! -e $plugin/bin/omarchy-nearby-helper ]] \
+  || report "an invalid release must fail before changing the installation"
+teardown
+
+announce "a checksum naming another asset is refused"
+setup
+hash=$(sha256sum "$FAKE_ASSET_FILE"); hash=${hash%% *}
+printf '%s  another-helper\n' "$hash" >"$FAKE_CHECKSUM_FILE"
+output=$(run_installer); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "checksum is malformed"
+assert_eq "$(installed_helper)" "old helper"
+teardown
+
+if (( failures )); then
+  echo "installer tests failed: $failures" >&2
+  exit 1
+fi
+echo "installer tests passed"

--- a/tests/service-state.test.js
+++ b/tests/service-state.test.js
@@ -147,7 +147,7 @@ function helperDerived(state) {
 
 const functionNames = [
   "viewOpened", "viewClosed", "notificationNeeded",
-  "send", "bindBackendRunning", "persistReceiverEnabled", "toggleReceiver", "finishReceiverShutdown",
+  "send", "utf8ByteLength", "bindBackendRunning", "persistReceiverEnabled", "toggleReceiver", "finishReceiverShutdown",
   "startDiscovery", "forceFullDiscovery", "stopDiscovery", "chooseDevice", "clearTarget",
   "openIncomingPinSettings", "beginIncomingPinEdit", "requestDisableIncomingPin",
   "cancelIncomingPinSettings", "submitIncomingPin", "confirmDisableIncomingPin",
@@ -224,6 +224,7 @@ function engine(initial = {}) {
     pendingIncomingPinEnabled: null,
     incomingPinError: "",
     transferSequence: 0,
+    maxOutgoingTextBytes: 1024 * 1024,
     ...initial,
   }
   Object.defineProperty(context, "incoming", {get() { return Model.currentIncoming(context.incomingQueue) }})
@@ -262,6 +263,23 @@ function notificationTitles(state) {
 
 function notificationCommands(state) {
   return state.notified.map(command => Array.from(command))
+}
+
+{
+  const exact = engine()
+  exact.beginOutgoing({kind: "text", device: exact.selectedDevice, text: "x".repeat(1024 * 1024)})
+  assert.equal(exact.sent.length, 1, "text at the byte limit must be sent")
+
+  const oversized = engine()
+  oversized.beginOutgoing({kind: "text", device: oversized.selectedDevice, text: "x".repeat(1024 * 1024 + 1)})
+  assert.equal(oversized.sent.length, 0, "text above the byte limit must not reach the helper")
+  assert.equal(oversized.pendingOutgoing, null)
+  assert.match(oversized.errorText, /maximum 1 MiB/)
+
+  assert.equal(exact.utf8ByteLength("ñ".repeat(512 * 1024)), 1024 * 1024,
+    "the UI limit must count UTF-8 bytes rather than JavaScript code units")
+  assert.equal(exact.utf8ByteLength("😀"), 4,
+    "a surrogate pair must count as one four-byte UTF-8 scalar")
 }
 
 {

--- a/tests/updater.test.sh
+++ b/tests/updater.test.sh
@@ -81,6 +81,10 @@ fi
 
 sleep "${FAKE_ASSET_DELAY:-0}"
 (( ${FAKE_ASSET_EXIT:-0} == 0 )) || exit "$FAKE_ASSET_EXIT"
+if [[ ${FAKE_ASSET_SYMLINK:-0} == 1 ]]; then
+  ln -s "$FAKE_ASSET_FILE" "$output"
+  exit 0
+fi
 cp "$FAKE_ASSET_FILE" "$output"
 exit 0
 STUB
@@ -102,7 +106,7 @@ STUB
 teardown() {
   [[ -n ${sandbox:-} && -d $sandbox ]] && rm -rf -- "$sandbox"
   unset FAKE_RELEASE_JSON FAKE_ASSET_FILE FAKE_CHECKSUM_FILE
-  unset FAKE_HTTP_STATUS FAKE_LOOKUP_EXIT FAKE_ASSET_EXIT FAKE_CHECKSUM_EXIT FAKE_ASSET_DELAY
+  unset FAKE_HTTP_STATUS FAKE_LOOKUP_EXIT FAKE_ASSET_EXIT FAKE_CHECKSUM_EXIT FAKE_ASSET_DELAY FAKE_ASSET_SYMLINK
 }
 
 manifest() {
@@ -195,6 +199,52 @@ assert_contains "$output" "failed its SHA256 check"
 assert_eq "$(installed_helper)" "old helper" "an unverified binary must never be installed"
 assert_eq "$(staging_in_cache)" "0"
 assert_eq "$(staging_in_plugin)" "0"
+teardown
+
+announce "an oversized helper is discarded before verification"
+setup
+truncate -s $((32 * 1024 * 1024 + 1)) "$sandbox/served/$asset_name"
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "exceeds its download limit"
+assert_eq "$(installed_helper)" "old helper"
+teardown
+
+announce "a non-HTTPS asset URL is refused"
+setup
+sed -i 's#https://example.invalid/#http://example.invalid/#g' "$FAKE_RELEASE_JSON"
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "URL is not HTTPS"
+assert_eq "$(installed_helper)" "old helper"
+teardown
+
+announce "a checksum for a different asset is refused"
+setup
+hash=$(sha256sum "$FAKE_ASSET_FILE"); hash=${hash%% *}
+printf '%s  another-helper\n' "$hash" >"$FAKE_CHECKSUM_FILE"
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "checksum is malformed"
+assert_eq "$(installed_helper)" "old helper"
+teardown
+
+announce "a non-regular downloaded helper is refused"
+setup
+export FAKE_ASSET_SYMLINK=1
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "not a regular file"
+assert_eq "$(installed_helper)" "old helper"
+teardown
+
+announce "oversized release metadata is refused before parsing"
+setup
+truncate -s $((1024 * 1024 + 1)) "$FAKE_RELEASE_JSON"
+output=$(run_updater); status=$?
+assert_eq "$status" "1"
+assert_contains "$output" "metadata exceeds its download limit"
+assert_eq "$(installed_helper)" "old helper"
 teardown
 
 # "no such release" and "no network" are different problems with different


### PR DESCRIPTION
## Summary

- bound helper IPC, outgoing text, and peer registry growth
- validate and atomically persist the TLS identity without silent rotation
- pin the Rust/CI baseline and enforce Clippy warnings
- harden helper downloads and add build-provenance verification
- establish an independent helper release cycle for the future launcher

The explicit Axum metadata limit remains deferred because it requires changing the vendored `localsend-rs`. Launcher metadata will be added after the first helper artifact is built and attested from a CI-passing commit.

## Validation

- Node model, panel, and service suites
- installer and updater Bash suites
- cargo fmt/check/clippy/test with `--locked`
- vendored localsend-rs suite with HTTPS